### PR TITLE
fix(prompts): prevent agent from commenting on unrelated issues/PRs

### DIFF
--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -1,10 +1,11 @@
 # Agent Request
 
-@{{ author }} mentioned you in {{ repository }} #{{ number }}.
+@{{ author }} requested work in {{ repository }}.
 
 ## Context
 
 - **Context Type**: {{ context_type }}
+- **Target**: {{ number }}
 - **Default Branch**: {{ default_branch }}
 
 ## User's Request
@@ -16,6 +17,22 @@
 ---
 
 ## Instructions
+
+### For `dispatch` (workflow_dispatch with no target)
+
+1. **DO NOT comment on any issue or PR** - there is no target.
+2. **Plan your work** using todo tools.
+3. **Investigate and satisfy the request** silently.
+4. **If you need to report findings**, create a NEW issue:
+   ```bash
+   gh issue create --title "Title" --body "Body"
+   ```
+5. **If code changes are needed**, create a branch:
+   ```bash
+   git checkout -b feat/short-description
+   ```
+
+### For `issue_comment`, `pr_comment`, `pr_inline_comment`
 
 1. **Gather context first:**
    ```bash
@@ -35,18 +52,25 @@
 4. **Investigate and satisfy the request.**
 
 5. **If code changes are needed:**
-   - **For PR comments** (`context_type` = `pr_comment`):
+   - **For PR comments** (`context_type` = `pr_comment` or `pr_inline_comment`):
      You are already on the PR branch. Commit directly to the current branch.
-   - **For issue comments or dispatch** (`context_type` = `issue_comment` or `dispatch`):
+   - **For issue comments** (`context_type` = `issue_comment`):
      Create a branch: `git checkout -b fix/issue-{{ number }}-short-description`
 
-6. **NEVER run `git push`** - the action automatically handles pushing with
-   signed commits after you're done. Just make your commits locally.
+6. **Report completion** via comment on #{{ number }}.
 
-7. **NEVER run `gh pr create`** - the action automatically creates PRs when
-   you push to a new branch.
+---
 
-8. **NEVER reference commit SHAs** in comments or reports - the SHAs change
-   when commits are replayed as signed commits.
+## Global Rules
 
-9. **Report completion** via comment on the issue/PR.
+- **NEVER run `git push`** - the action automatically handles pushing with
+  signed commits after you're done. Just make your commits locally.
+
+- **NEVER run `gh pr create`** - the action automatically creates PRs when
+  you push to a new branch.
+
+- **NEVER reference commit SHAs** in comments or reports - the SHAs change
+  when commits are replayed as signed commits.
+
+- **NEVER comment on unrelated issues/PRs** - only interact with #{{ number }}
+  (or create new issues if reporting findings from dispatch).

--- a/prompts/base/github_env.md
+++ b/prompts/base/github_env.md
@@ -26,3 +26,14 @@ These files contain project conventions, coding standards, and AI-specific guida
 - NEVER reference commit SHAs - they change when replayed as signed commits
 - Acknowledge requests immediately, report when done
 - Use todo tools to track your work
+
+### Comment Scope (CRITICAL)
+
+**Only comment on the specific issue/PR you were triggered from.**
+
+- If triggered from issue #42 → only comment on #42
+- If triggered from PR #15 → only comment on #15
+- If triggered via `workflow_dispatch` with no target → **DO NOT comment on any issue/PR**
+  - Just do the work silently (commits, file changes)
+  - If you need to report findings, create a NEW issue rather than commenting on unrelated ones
+- NEVER comment on unrelated issues/PRs just because they exist or seem relevant


### PR DESCRIPTION
- Add 'Comment Scope' section to github_env.md with explicit rules
- Restructure agent.md with separate instructions per context type
- For dispatch: work silently, create new issues for findings
- For issue/pr comments: only interact with the target number