### PR TITLE
security: prevent script injection via two-checkout pattern

### DIFF
--- a/.github/workflows/agent.yaml
+++ b/.github/workflows/agent.yaml
@@ -56,7 +56,22 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Checkout
+      # SECURITY: Checkout trusted action FIRST to prevent malicious script injection
+      # If we only checkout the PR branch and use `uses: ./`, an attacker could modify
+      # scripts/replay_commits.py in their PR and it would run with GH_TOKEN access.
+      - name: Checkout action (trusted)
+        # yamllint disable-line rule:line-length rule:comments
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          ref: main
+          path: .trusted-action
+          sparse-checkout: |
+            action.yaml
+            scripts
+            prompts
+
+      # Now checkout the working branch (PR or main) for the agent to operate on
+      - name: Checkout working branch
         # yamllint disable-line rule:line-length rule:comments
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
@@ -77,8 +92,9 @@ jobs:
             echo "value=agent" >> "$GITHUB_OUTPUT"
           fi
 
+      # Use the TRUSTED action, which operates on the working branch in workspace
       - name: Run Agent
-        uses: ./
+        uses: ./.trusted-action
         with:
           bot_name: dobbyphus
           auth_json: ${{ secrets.COPILOT_AUTH_JSON }}

--- a/action.yaml
+++ b/action.yaml
@@ -359,6 +359,7 @@ runs:
         echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
         exit 0
       env:
+        ACTION_PATH: ${{ github.action_path }}
         MODE: ${{ inputs.mode }}
         PROMPT_PATH: ${{ inputs.prompt_path }}
         PROMPT_VARS: ${{ steps.vars.outputs.json }}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -uo pipefail
 
-ACTION_PATH="${GITHUB_ACTION_PATH:-.}"
+ACTION_PATH="${ACTION_PATH:-.}"
 PROMPT_PATH="${PROMPT_PATH:-.github/prompts}"
 
 VARS_SCRIPT="$ACTION_PATH/scripts/vars.py"


### PR DESCRIPTION
When using `uses: ./` after checking out a PR branch, an attacker could modify scripts/replay_commits.py in their PR and have it run with github_token permissions.

Fix by checking out trusted action code from main to a separate path, then checking out the working branch. The action runs from the trusted path while operating on the working branch.