### PR TITLE
feat: auto-detect mode from comment content

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -189,6 +189,17 @@ runs:
         echo "$DIFF_HUNK" >> "$GITHUB_OUTPUT"
         echo "$EOF_MARKER" >> "$GITHUB_OUTPUT"
 
+    - name: Detect mode
+      id: mode
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_BOT_NAME: ${{ inputs.bot_name }}
+        COMMENT_BODY: ${{ github.event.comment.body }}
+        REVIEW_BODY: ${{ github.event.review.body }}
+      run: python3 "${{ github.action_path }}/scripts/detect_mode.py"
+
     - name: Build prompt_vars
       id: vars
       shell: bash
@@ -360,7 +371,7 @@ runs:
         exit 0
       env:
         ACTION_PATH: ${{ github.action_path }}
-        MODE: ${{ inputs.mode }}
+        MODE: ${{ steps.mode.outputs.value }}
         PROMPT_PATH: ${{ inputs.prompt_path }}
         PROMPT_VARS: ${{ steps.vars.outputs.json }}
         PROMPT: ${{ inputs.prompt }}

--- a/examples/agent.yaml
+++ b/examples/agent.yaml
@@ -64,23 +64,9 @@ jobs:
           fetch-depth: 0
           # token: ${{ steps.app-token.outputs.token }}
 
-      - name: Determine mode
-        id: mode
-        shell: bash
-        run: |
-          EVENT="${{ github.event_name }}"
-          if [[ "$EVENT" == "pull_request" ]] || \
-             [[ "$EVENT" == "pull_request_review" ]] || \
-             [[ "$EVENT" == "pull_request_review_comment" ]]; then
-            echo "value=review" >> "$GITHUB_OUTPUT"
-          else
-            echo "value=agent" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Run Agent
         uses: dobbyphus/action@main
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           bot_name: ${{ vars.BOT_NAME || 'ai-agent' }}
           # github_token: ${{ steps.app-token.outputs.token }}
-          mode: ${{ steps.mode.outputs.value }}

--- a/scripts/detect_mode.py
+++ b/scripts/detect_mode.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Detect agent mode from event context."""
+
+import os
+import re
+
+
+def is_review_request(body: str, bot_name: str) -> bool:
+    """Check if the comment is requesting a review.
+
+    Returns True if:
+    1. The comment mentions @bot_name, AND
+    2. The comment contains the word "review" (case-insensitive, whole word)
+
+    Args:
+        body: The comment or review body text
+        bot_name: The bot's mention name (without @)
+
+    Returns:
+        True if this is a review request, False otherwise
+    """
+    if not body or not bot_name:
+        return False
+
+    # Check for @bot_name mention (case-insensitive)
+    # GitHub usernames can contain alphanumeric and hyphens, so we need to
+    # ensure we're not matching a partial username (e.g., @dobbyphus-bot)
+    mention_pattern = re.compile(
+        rf"@{re.escape(bot_name)}(?![a-zA-Z0-9-])", re.IGNORECASE
+    )
+    if not mention_pattern.search(body):
+        return False
+
+    # Check for "review" as a whole word (not "reviewed", "reviewer", etc.)
+    review_pattern = re.compile(r"\breview\b", re.IGNORECASE)
+    return bool(review_pattern.search(body))
+
+
+def detect_mode(
+    event_name: str,
+    input_mode: str,
+    bot_name: str,
+    comment_body: str | None = None,
+    review_body: str | None = None,
+) -> str:
+    """Detect the effective mode based on event context.
+
+    Priority:
+    1. pull_request event (reviewer assigned) → review
+    2. Comment contains @bot_name + "review" → review
+    3. Explicit input_mode (if not default "agent") → input_mode
+    4. Default → agent
+
+    Args:
+        event_name: GitHub event name (e.g., "issue_comment", "pull_request")
+        input_mode: The mode input from action configuration
+        bot_name: The bot's mention name
+        comment_body: Body of issue/PR comment (if applicable)
+        review_body: Body of PR review (if applicable)
+
+    Returns:
+        The detected mode: "agent" or "review"
+    """
+    # Assigned as reviewer - use review mode
+    if event_name == "pull_request":
+        return "review"
+
+    # Check comment/review body for review request
+    body = comment_body or review_body or ""
+    if is_review_request(body, bot_name):
+        return "review"
+
+    # User explicitly set a different mode
+    if input_mode and input_mode != "agent":
+        return input_mode
+
+    # Default to agent mode
+    return "agent"
+
+
+def main() -> None:
+    """Entry point - reads from environment and outputs detected mode."""
+    event_name = os.environ.get("EVENT_NAME", "")
+    input_mode = os.environ.get("INPUT_MODE", "agent")
+    bot_name = os.environ.get("INPUT_BOT_NAME", "ai-agent")
+    comment_body = os.environ.get("COMMENT_BODY", "")
+    review_body = os.environ.get("REVIEW_BODY", "")
+
+    mode = detect_mode(
+        event_name=event_name,
+        input_mode=input_mode,
+        bot_name=bot_name,
+        comment_body=comment_body,
+        review_body=review_body,
+    )
+
+    print(f"Detected mode: {mode}")
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a") as f:
+            f.write(f"value={mode}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_detect_mode.py
+++ b/tests/test_detect_mode.py
@@ -1,0 +1,180 @@
+"""Tests for detect_mode.py"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from detect_mode import detect_mode, is_review_request
+
+
+class TestIsReviewRequest:
+    """Tests for is_review_request function."""
+
+    def test_empty_body(self):
+        assert is_review_request("", "dobbyphus") is False
+
+    def test_empty_bot_name(self):
+        assert is_review_request("@dobbyphus review", "") is False
+
+    def test_no_mention(self):
+        assert is_review_request("please review this", "dobbyphus") is False
+
+    def test_no_review_word(self):
+        assert is_review_request("@dobbyphus fix this bug", "dobbyphus") is False
+
+    def test_simple_review(self):
+        assert is_review_request("@dobbyphus review", "dobbyphus") is True
+
+    def test_review_with_comma(self):
+        assert is_review_request("@dobbyphus, review this", "dobbyphus") is True
+
+    def test_review_with_colon(self):
+        assert is_review_request("@dobbyphus: can you review this", "dobbyphus") is True
+
+    def test_please_review(self):
+        assert is_review_request("@dobbyphus, please review this", "dobbyphus") is True
+
+    def test_review_this_pr(self):
+        assert is_review_request("@dobbyphus - review the PR", "dobbyphus") is True
+
+    def test_can_you_review(self):
+        assert is_review_request("@dobbyphus can you review this?", "dobbyphus") is True
+
+    def test_review_before_mention(self):
+        # "review" appears before mention - still valid
+        assert is_review_request("please review @dobbyphus", "dobbyphus") is True
+
+    def test_multiline_review(self):
+        body = """Hey @dobbyphus,
+
+Can you please review this change?
+
+Thanks!"""
+        assert is_review_request(body, "dobbyphus") is True
+
+    def test_case_insensitive_mention(self):
+        assert is_review_request("@Dobbyphus review", "dobbyphus") is True
+        assert is_review_request("@DOBBYPHUS review", "dobbyphus") is True
+
+    def test_case_insensitive_review(self):
+        assert is_review_request("@dobbyphus REVIEW this", "dobbyphus") is True
+        assert is_review_request("@dobbyphus Review this", "dobbyphus") is True
+
+    def test_reviewed_not_matched(self):
+        # "reviewed" should not trigger review mode
+        assert is_review_request("@dobbyphus I reviewed this", "dobbyphus") is False
+
+    def test_reviewer_not_matched(self):
+        # "reviewer" should not trigger review mode
+        assert is_review_request("@dobbyphus add me as reviewer", "dobbyphus") is False
+
+    def test_reviewing_not_matched(self):
+        # "reviewing" should not trigger review mode
+        assert is_review_request("@dobbyphus I'm reviewing now", "dobbyphus") is False
+
+    def test_partial_bot_name_not_matched(self):
+        # Should not match partial bot names
+        assert is_review_request("@dobbyphus-bot review", "dobbyphus") is False
+        assert is_review_request("@dobbyphus123 review", "dobbyphus") is False
+
+    def test_different_bot_name(self):
+        assert is_review_request("@ai-agent review", "ai-agent") is True
+        assert is_review_request("@my_bot review this", "my_bot") is True
+
+
+class TestDetectMode:
+    """Tests for detect_mode function."""
+
+    def test_pull_request_event_always_review(self):
+        # Assigned as reviewer - always review mode
+        result = detect_mode(
+            event_name="pull_request",
+            input_mode="agent",
+            bot_name="dobbyphus",
+            comment_body="",
+        )
+        assert result == "review"
+
+    def test_issue_comment_with_review_request(self):
+        result = detect_mode(
+            event_name="issue_comment",
+            input_mode="agent",
+            bot_name="dobbyphus",
+            comment_body="@dobbyphus please review this",
+        )
+        assert result == "review"
+
+    def test_issue_comment_without_review(self):
+        result = detect_mode(
+            event_name="issue_comment",
+            input_mode="agent",
+            bot_name="dobbyphus",
+            comment_body="@dobbyphus fix this bug",
+        )
+        assert result == "agent"
+
+    def test_pr_review_comment_with_review_request(self):
+        result = detect_mode(
+            event_name="pull_request_review_comment",
+            input_mode="agent",
+            bot_name="dobbyphus",
+            comment_body="@dobbyphus, can you review this?",
+        )
+        assert result == "review"
+
+    def test_review_body_used_when_comment_empty(self):
+        result = detect_mode(
+            event_name="pull_request_review",
+            input_mode="agent",
+            bot_name="dobbyphus",
+            comment_body="",
+            review_body="@dobbyphus review please",
+        )
+        assert result == "review"
+
+    def test_explicit_review_mode_input(self):
+        result = detect_mode(
+            event_name="issue_comment",
+            input_mode="review",
+            bot_name="dobbyphus",
+            comment_body="@dobbyphus fix this",
+        )
+        assert result == "review"
+
+    def test_explicit_custom_mode_input(self):
+        result = detect_mode(
+            event_name="issue_comment",
+            input_mode="custom",
+            bot_name="dobbyphus",
+            comment_body="@dobbyphus do something",
+        )
+        assert result == "custom"
+
+    def test_default_agent_mode(self):
+        result = detect_mode(
+            event_name="issue_comment",
+            input_mode="agent",
+            bot_name="dobbyphus",
+            comment_body="@dobbyphus implement this feature",
+        )
+        assert result == "agent"
+
+    def test_workflow_dispatch_default_agent(self):
+        result = detect_mode(
+            event_name="workflow_dispatch",
+            input_mode="agent",
+            bot_name="dobbyphus",
+            comment_body="",
+        )
+        assert result == "agent"
+
+    def test_none_bodies(self):
+        result = detect_mode(
+            event_name="issue_comment",
+            input_mode="agent",
+            bot_name="dobbyphus",
+            comment_body=None,
+            review_body=None,
+        )
+        assert result == "agent"


### PR DESCRIPTION
- Add 'Detect mode' step in action that parses comment body
- @bot_name review → review mode (no changes allowed)
- @bot_name [anything else] → agent mode (can make changes)
- pull_request event (reviewer assigned) → review mode
- Simplify examples/agent.yaml by removing workflow-level mode detection