### PR TITLE
fix: use correct API endpoints for PR comment reactions and replies

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -228,6 +228,7 @@ runs:
           --arg author "${{ steps.context.outputs.author }}" \
           --arg bot_name "$INPUT_BOT_NAME" \
           --arg comment "${{ steps.context.outputs.comment }}" \
+          --arg comment_id "${{ steps.context.outputs.comment_id }}" \
           --arg context_type "$CONTEXT_TYPE" \
           --arg number "${{ steps.context.outputs.number }}" \
           --arg repository "${{ github.repository }}" \
@@ -245,6 +246,7 @@ runs:
             author: $author,
             bot_name: $bot_name,
             comment: $comment,
+            comment_id: $comment_id,
             context_type: $context_type,
             number: $number,
             repository: $repository,
@@ -288,8 +290,16 @@ runs:
       run: |
         REPO="${{ github.repository }}"
         COMMENT_ID="${{ steps.context.outputs.comment_id }}"
-        gh api "/repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
-          -X POST -f content="eyes" || true
+        EVENT="${{ github.event_name }}"
+
+        # PR review comments use a different API endpoint than issue comments
+        if [[ "$EVENT" == "pull_request_review_comment" ]]; then
+          ENDPOINT="/repos/$REPO/pulls/comments/$COMMENT_ID/reactions"
+        else
+          ENDPOINT="/repos/$REPO/issues/comments/$COMMENT_ID/reactions"
+        fi
+
+        gh api "$ENDPOINT" -X POST -f content="eyes" || true
 
     - name: Add working label
       if: steps.context.outputs.number != ''
@@ -411,7 +421,14 @@ runs:
       run: |
         REPO="${{ github.repository }}"
         COMMENT_ID="${{ steps.context.outputs.comment_id }}"
-        ENDPOINT="/repos/$REPO/issues/comments/$COMMENT_ID/reactions"
+        EVENT="${{ github.event_name }}"
+
+        # PR review comments use a different API endpoint than issue comments
+        if [[ "$EVENT" == "pull_request_review_comment" ]]; then
+          ENDPOINT="/repos/$REPO/pulls/comments/$COMMENT_ID/reactions"
+        else
+          ENDPOINT="/repos/$REPO/issues/comments/$COMMENT_ID/reactions"
+        fi
 
         REACTION_ID=$(gh api "$ENDPOINT" \
           --jq '.[] | select(.content == "eyes") | .id' | head -1)

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -7,6 +7,7 @@ Review PR #{{ pr_number }}: {{ pr_title }}
 - **Author**: @{{ pr_author }}
 - **Requested by**: @{{ requested_by }}
 - **Repository**: {{ repository }}
+- **Context Type**: {{ context_type }}
 
 {{ inline_context }}
 
@@ -16,6 +17,24 @@ Review PR #{{ pr_number }}: {{ pr_title }}
 gh pr view {{ pr_number }} --json files,reviewThreads,commits,additions,deletions
 gh pr diff {{ pr_number }}
 ```
+
+## Responding to Inline Comments
+
+When `context_type` is `pr_inline_comment`, you MUST reply in the same thread
+using the GitHub API (NOT `gh issue comment` or `gh pr review`):
+
+```bash
+gh api repos/{{ repository }}/pulls/{{ pr_number }}/comments \
+  -X POST \
+  -f body="$(cat <<'EOF'
+Your reply here
+EOF
+)" \
+  -F in_reply_to={{ comment_id }}
+```
+
+This ensures your response appears in the correct inline thread, not as a
+separate PR comment.
 
 ## Review Guidelines
 


### PR DESCRIPTION
- Use pulls/comments endpoint for reactions on inline diff comments
- Add comment_id to prompt_vars for inline reply threading
- Add instructions in review.md for replying in-thread with in_reply_to