### PR TITLE
fix: handle detached HEAD for PR review comment events

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -275,10 +275,23 @@ runs:
     - name: Setup git
       id: git
       shell: bash
+      env:
+        HEAD_REF: ${{ github.head_ref }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
         echo "start_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-        BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+        # Determine branch: github.head_ref (PR events), PR head ref (review events),
+        # or detect from git (may be "HEAD" if detached)
+        if [[ -n "$HEAD_REF" ]]; then
+          BRANCH="$HEAD_REF"
+        elif [[ -n "$PR_HEAD_REF" ]]; then
+          BRANCH="$PR_HEAD_REF"
+        else
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        fi
         echo "start_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 

--- a/examples/agent.yaml
+++ b/examples/agent.yaml
@@ -60,7 +60,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref }}
+          # github.head_ref: PR events (pull_request, pull_request_target)
+          # github.event.pull_request.head.ref: PR review/comment events
+          # github.ref: fallback for other events
+          # yamllint disable-line rule:line-length
+          ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           fetch-depth: 0
           # token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
github.head_ref is only set for pull_request events, not for pull_request_review_comment events. Add github.event.pull_request.head.ref as fallback to correctly determine the branch name.

- Update examples/agent.yaml checkout ref with 3-way fallback
- Update action.yaml Setup git step with proper branch detection