### PR TITLE
fix(prompts): add intent classification and branch requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,52 @@ def test_file_operation(self):
         assert result == expected
 ```
 
+## Commit & Pull Request Guidelines
+
+Follow Linux kernel commit message style:
+
+### Subject line
+- **50 characters or less** (hard limit: 72)
+- Imperative mood ("Add feature" not "Added feature" or "Adds feature")
+- Use conventional commit format: `type(scope): description`
+  - Types: `fix`, `feat`, `chore`, `refactor`, `test`, `perf`, `docs`
+  - Scopes: `prompts`, `scripts`, `action`, `ci`, `deps`, etc.
+- No period at end
+- Examples:
+  - `fix(prompts): clarify branch creation requirements`
+  - `feat(action): add model preset configuration`
+  - `chore(docs): update README with new inputs`
+  - `chore(deps): update oh-my-opencode to v1.2.0`
+
+### Body
+- Separate from subject with a blank line
+- **Wrap at 72 characters**
+- Explain *what* and *why*, not *how* (the code shows how)
+- Use prose, not bullet points: describe the problem, the fix, and why it helps
+- Reference issues/PRs at the bottom if applicable
+
+### Example
+```
+feat(prompts): add intent classification for research vs implementation
+
+Agent previously treated all requests as implementation tasks, leading
+to unwanted code changes when users only wanted investigation. The
+"research this issue" command resulted in commits that were rejected
+because no branch was created.
+
+Add explicit intent classification section that distinguishes RESEARCH
+mode (investigate and report) from IMPLEMENTATION mode (create branch
+and code). Include trigger word lists and clear examples to guide the
+agent's behavior.
+
+Closes #42
+```
+
+### Pull Requests
+- Describe what/why in the PR body
+- List commands run (`pytest tests/ -v`, linting, etc.)
+- Link related issues/TODOs
+
 ## Action Development
 
 ### Adding New Inputs

--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -17,6 +17,49 @@ Work requested in {{ repository }}.
 
 ---
 
+## Intent Classification (DETERMINE FIRST)
+
+Before taking any action, classify the request:
+
+### RESEARCH Mode
+
+**Trigger words**: "research", "investigate", "analyze", "look into", "review", "check", "explore", "understand", "explain", "examine", "assess", "evaluate", "diagnose"
+
+**What to do**:
+- Gather information and analyze
+- Read code, issues, logs, documentation
+- Report findings via comment on #{{ number }}
+- **DO NOT write code, create branches, or make commits**
+
+**Output**: A comment summarizing findings, root causes, recommendations
+
+### IMPLEMENTATION Mode
+
+**Trigger words**: "fix", "implement", "create", "add", "update", "change", "build", "make", "refactor", "migrate", "upgrade", "resolve", "address" (as in "address this bug")
+
+**What to do**:
+- **FIRST**: Create a branch (`git checkout -b <branch-name>`)
+- Then: Write code, tests, make commits
+- The workflow handles push and PR creation
+
+**CRITICAL**: If IMPLEMENTATION mode, you MUST create a branch BEFORE any code changes.
+
+### Mixed Requests
+
+If a request contains BOTH research AND implementation language (e.g., "investigate and fix"):
+- Default to **RESEARCH first**: understand the problem fully
+- Ask for confirmation before implementing OR
+- If clearly actionable, proceed to IMPLEMENTATION with branch creation
+
+### When in Doubt
+
+- "research this issue" → RESEARCH only
+- "look into this and create a PR" → IMPLEMENTATION (explicit PR request)
+- "investigate the bug" → RESEARCH only
+- "fix the bug" → IMPLEMENTATION
+
+---
+
 ## Instructions
 
 ### Required First Steps (NON-NEGOTIABLE)
@@ -158,31 +201,46 @@ When handling ALL unresolved threads:
 
 ### For `issue_comment`, `pr_comment`
 
-1. **Gather context first:**
+1. **Classify intent** (see Intent Classification above):
+   - RESEARCH → Investigate and report findings only
+   - IMPLEMENTATION → Create branch, then code
+
+2. **Gather context first:**
    ```bash
    gh issue view {{ number }} --json title,body,state,labels,comments
    ```
 
-2. **Acknowledge immediately** with requirements + TODOs:
+3. **Acknowledge immediately** with your classification + TODOs:
    ```bash
    gh issue comment {{ number }} --body "$(cat <<'EOF'
    {{ author_mention }} I have read the full thread. Here's my understanding and plan:
 
-   - Requirements: ...
-   - TODOs: ...
+   - **Mode**: [RESEARCH / IMPLEMENTATION]
+   - **Requirements**: ...
+   - **TODOs**: ...
    EOF
    )"
    ```
 
-3. **Plan your work** using todo tools.
+4. **Plan your work** using todo tools.
 
-4. **Investigate and satisfy the request.**
+5. **Execute based on mode:**
 
-5. **If code changes are needed:**
+   **If RESEARCH mode:**
+   - Investigate: read code, analyze, gather information
+   - **DO NOT** write code, create branches, or make commits
+   - Report findings via comment on #{{ number }}
+
+   **If IMPLEMENTATION mode:**
    - **For PR comments** (`context_type` = `pr_comment`):
      You are already on the PR branch. Commit directly to the current branch.
    - **For issue comments** (`context_type` = `issue_comment`):
-     Create a branch: `git checkout -b fix/issue-{{ number }}-short-description`
+     **FIRST**: Create a branch before ANY code changes:
+     ```bash
+     git checkout -b fix/issue-{{ number }}-short-description
+     git branch --show-current  # Verify NOT on main
+     ```
+   - Then: Make changes, write tests, commit
 
 6. **Report completion** via comment on #{{ number }}.
 

--- a/prompts/base/file_changes.md
+++ b/prompts/base/file_changes.md
@@ -1,14 +1,42 @@
 ## Git Workflow
 
-You MUST create a branch for your work. Commits to the default branch are not allowed.
+### BLOCKING: Branch Verification (BEFORE ANY CODE CHANGES)
+
+**Commits to the default branch (main/master) are REJECTED by the system.**
+
+Before writing ANY code, editing ANY file, or making ANY commit:
+
+```bash
+# Check current branch
+git branch --show-current
+```
+
+- If output is `main` or `master` → **STOP. Create a branch first.**
+- If output is a feature branch → Proceed with changes.
 
 ### Required Workflow
 
-1. Create a branch: `git checkout -b <branch-name>`
-   - Use descriptive names: `fix/typo-in-readme`, `feat/add-auth`, `issue-42-fix-login`
-2. Make your changes and commit with clear messages
-3. Your commits are automatically signed and pushed
-4. A pull request is automatically created
+1. **FIRST**: Create a branch (MANDATORY for any code changes):
+   ```bash
+   git checkout -b <branch-name>
+   ```
+   - For issues: `fix/issue-{{ number }}-short-description` or `feat/issue-{{ number }}-description`
+   - General: `fix/typo-in-readme`, `feat/add-auth`
+
+2. **VERIFY** you are on the new branch:
+   ```bash
+   git branch --show-current  # Must NOT be main/master
+   ```
+
+3. Make your changes and commit with clear messages
+
+4. Your commits are automatically signed and pushed
+
+5. A pull request is automatically created
+
+### Why This Matters
+
+The replay system WILL FAIL if you commit to the default branch. Your work will be lost. Always branch first.
 
 ### What You CAN Do
 


### PR DESCRIPTION
Agent failed when given "research this issue" because it treated all requests as implementation tasks, making commits directly to main. The replay system correctly rejected these commits, but the work was lost.

Add explicit intent classification section that distinguishes RESEARCH mode (investigate and report only) from IMPLEMENTATION mode (create branch first, then code). Research keywords like "investigate" and "analyze" now prevent code changes, while implementation keywords trigger branch creation.

Also strengthen branch verification in file_changes.md to make it a blocking prerequisite with explicit verification steps. Add commit message guidelines to AGENTS.md following Linux kernel style.