### PR TITLE
feat(scripts): add GitHub Actions output formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ See [`examples/agent.yaml`](./examples/agent.yaml) for a complete workflow with 
 | `auth_json` | - | Full auth.json content (advanced) |
 | `agent_keywords` | `ultrawork` | Keywords to prepend for agent mode (triggers oh-my-opencode modes) |
 | `review_keywords` | `analyze` | Keywords to prepend for review mode (triggers oh-my-opencode modes) |
+| `format_output` | `true` | Format output with collapsible sections for GitHub Actions logs |
 
 ## How It Works
 

--- a/action.yaml
+++ b/action.yaml
@@ -98,6 +98,11 @@ inputs:
     required: false
     default: analyze
 
+  format_output:
+    description: Format output with collapsible sections for GitHub Actions logs
+    required: false
+    default: "true"
+
 runs:
   using: composite
 
@@ -468,6 +473,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         AGENT_KEYWORDS: ${{ inputs.agent_keywords }}
         REVIEW_KEYWORDS: ${{ inputs.review_keywords }}
+        FORMAT_OUTPUT: ${{ inputs.format_output }}
 
     # === TEARDOWN (always runs) ===
     - name: Replay commits as signed

--- a/scripts/format_output.py
+++ b/scripts/format_output.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Format opencode JSON output for GitHub Actions logs."""
+
+import json
+import shutil
+import subprocess
+import sys
+from typing import IO, TextIO
+
+TOOL_ICONS = {
+    "read": "📄",
+    "write": "✏️",
+    "edit": "✏️",
+    "bash": "🔨",
+    "grep": "🔍",
+    "glob": "🔍",
+    "task": "🤖",
+    "todowrite": "📋",
+    "todoread": "📋",
+    "webfetch": "🌐",
+    "lsp_diagnostics": "🔬",
+    "lsp_hover": "🔬",
+    "lsp_goto_definition": "🔬",
+    "lsp_find_references": "🔬",
+    "ast_grep_search": "🌳",
+    "ast_grep_replace": "🌳",
+}
+
+DEFAULT_ICON = "🔧"
+
+
+def get_tool_icon(tool_name: str) -> str:
+    """Get icon for a tool, case-insensitive."""
+    return TOOL_ICONS.get(tool_name.lower(), DEFAULT_ICON)
+
+
+def format_tool_name(name: str) -> str:
+    """Format tool name for display."""
+    return name.replace("_", " ").title()
+
+
+def truncate_content(content: str, max_lines: int = 50) -> str:
+    """Truncate content if too long."""
+    lines = content.split("\n")
+    if len(lines) <= max_lines:
+        return content
+    return "\n".join(lines[:max_lines]) + f"\n... ({len(lines) - max_lines} more lines)"
+
+
+def format_tool_input(tool_name: str, tool_input: dict) -> str:
+    """Format tool input for the group title."""
+    name_lower = tool_name.lower()
+
+    if name_lower in ("read", "write", "edit"):
+        return tool_input.get("filePath", "")
+    elif name_lower == "bash":
+        cmd = tool_input.get("command", "")
+        return cmd[:60] + "..." if len(cmd) > 60 else cmd
+    elif name_lower in ("grep", "glob"):
+        pattern = tool_input.get("pattern", "")
+        return pattern[:40] + "..." if len(pattern) > 40 else pattern
+    elif name_lower == "task":
+        return tool_input.get("description", "")
+    elif name_lower in ("todowrite", "todoread"):
+        return ""
+    elif name_lower == "webfetch":
+        url = tool_input.get("url", "")
+        return url[:50] + "..." if len(url) > 50 else url
+
+    return ""
+
+
+def print_group_start(title: str, output: TextIO = sys.stdout) -> None:
+    print(f"::group::{title}", file=output, flush=True)
+
+
+def print_group_end(output: TextIO = sys.stdout) -> None:
+    print("::endgroup::", file=output, flush=True)
+
+
+STATUS_ICONS = {
+    "completed": "✅",
+    "in_progress": "🔄",
+    "pending": "⬚",
+    "cancelled": "❌",
+}
+
+
+def format_todos(todos: list) -> str:
+    lines = []
+    for todo in todos:
+        status = todo.get("status", "pending")
+        content = todo.get("content", "")
+        icon = STATUS_ICONS.get(status, "•")
+        lines.append(f"{icon} {content}")
+    return "\n".join(lines)
+
+
+def format_tool_output(tool_name: str, tool_input: dict, tool_output: str) -> str:
+    if tool_name.lower() == "todowrite":
+        todos = tool_input.get("todos", [])
+        if todos:
+            return format_todos(todos)
+    return truncate_content(tool_output) if tool_output else ""
+
+
+def handle_tool_use(part: dict, output: TextIO = sys.stdout) -> None:
+    tool_name = part.get("tool", part.get("name", "unknown"))
+    state = part.get("state", {})
+    tool_input = state.get("input", part.get("input", {}))
+    tool_output = state.get("output", "")
+
+    icon = get_tool_icon(tool_name)
+    formatted_name = format_tool_name(tool_name)
+    input_summary = format_tool_input(tool_name, tool_input)
+
+    if input_summary:
+        title = f"{icon} {formatted_name}: {input_summary}"
+    else:
+        title = f"{icon} {formatted_name}"
+
+    print_group_start(title, output)
+
+    formatted_output = format_tool_output(tool_name, tool_input, tool_output)
+    if formatted_output:
+        print(formatted_output, file=output, flush=True)
+
+    print_group_end(output)
+
+
+def handle_tool_result(part: dict, output: TextIO = sys.stdout) -> None:
+    content = part.get("content", "")
+
+    if content:
+        print("---", file=output, flush=True)
+        print(truncate_content(content), file=output, flush=True)
+
+    print_group_end(output)
+
+
+def handle_text(part: dict, output: TextIO = sys.stdout) -> None:
+    text = part.get("text", "")
+    if text.strip():
+        print(text, file=output, flush=True)
+
+
+SKIP_EVENT_TYPES = {"step_start", "step_finish"}
+
+
+def process_event(event: dict, output: TextIO = sys.stdout) -> None:
+    event_type = event.get("type", "")
+    part = event.get("part", {})
+
+    if event_type in SKIP_EVENT_TYPES:
+        return
+    elif event_type == "tool_use":
+        handle_tool_use(part, output)
+    elif event_type == "tool_result":
+        handle_tool_result(part, output)
+    elif event_type == "text":
+        handle_text(part, output)
+    else:
+        print(json.dumps(event), file=output, flush=True)
+
+
+def process_stream(stream: IO[str], output: TextIO = sys.stdout) -> None:
+    for line in stream:
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            event = json.loads(line)
+            process_event(event, output)
+        except json.JSONDecodeError:
+            print(line, file=output, flush=True)
+
+
+def run_opencode(prompt: str, output: TextIO = sys.stdout) -> int:
+    base_cmd = ["opencode", "run", "--format", "json", prompt]
+
+    # Use stdbuf to force line-buffered output from opencode
+    stdbuf = shutil.which("stdbuf")
+    if stdbuf:
+        cmd = [stdbuf, "-oL"] + base_cmd
+    else:
+        cmd = base_cmd
+
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    if process.stdout:
+        process_stream(process.stdout, output)
+
+    return process.wait()
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: format_output.py <prompt>", file=sys.stderr)
+        print("       opencode run --format json | format_output.py -", file=sys.stderr)
+        sys.exit(1)
+
+    if sys.argv[1] == "-":
+        process_stream(sys.stdin, sys.stdout)
+    else:
+        prompt = sys.argv[1]
+        exit_code = run_opencode(prompt, sys.stdout)
+        sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -48,9 +48,14 @@ if [[ -n "$KEYWORDS" ]]; then
 fi
 
 FINAL=$("$SUBSTITUTE_SCRIPT" "$VARS" <<< "$TEMPLATE")
+FORMAT_SCRIPT="$ACTION_PATH/scripts/format_output.py"
 
 set +e
-opencode run "$FINAL"
+if [[ "${FORMAT_OUTPUT:-true}" == "true" ]] && [[ "${GITHUB_ACTIONS:-}" == "true" ]] && [[ -f "$FORMAT_SCRIPT" ]]; then
+  python3 "$FORMAT_SCRIPT" "$FINAL"
+else
+  opencode run "$FINAL"
+fi
 EXIT_CODE=$?
 set -e
 

--- a/tests/test_format_output.py
+++ b/tests/test_format_output.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+
+import io
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from format_output import (
+    format_tool_input,
+    format_tool_name,
+    format_tool_output,
+    format_todos,
+    get_tool_icon,
+    handle_text,
+    handle_tool_result,
+    handle_tool_use,
+    print_group_end,
+    print_group_start,
+    process_event,
+    process_stream,
+    truncate_content,
+)
+
+
+class TestGetToolIcon:
+    def test_read_icon(self):
+        assert get_tool_icon("read") == "📄"
+
+    def test_bash_icon(self):
+        assert get_tool_icon("bash") == "🔨"
+
+    def test_case_insensitive(self):
+        assert get_tool_icon("READ") == "📄"
+        assert get_tool_icon("Bash") == "🔨"
+
+    def test_unknown_tool_default(self):
+        assert get_tool_icon("unknown_tool") == "🔧"
+
+    def test_lsp_tools(self):
+        assert get_tool_icon("lsp_diagnostics") == "🔬"
+        assert get_tool_icon("lsp_hover") == "🔬"
+
+
+class TestFormatToolName:
+    def test_simple_name(self):
+        assert format_tool_name("read") == "Read"
+
+    def test_underscore_name(self):
+        assert format_tool_name("lsp_diagnostics") == "Lsp Diagnostics"
+
+    def test_multiple_underscores(self):
+        assert format_tool_name("ast_grep_search") == "Ast Grep Search"
+
+
+class TestTruncateContent:
+    def test_short_content_unchanged(self):
+        content = "line1\nline2\nline3"
+        assert truncate_content(content, max_lines=10) == content
+
+    def test_long_content_truncated(self):
+        lines = [f"line{i}" for i in range(100)]
+        content = "\n".join(lines)
+        result = truncate_content(content, max_lines=5)
+        assert "line0" in result
+        assert "line4" in result
+        assert "line5" not in result
+        assert "(95 more lines)" in result
+
+    def test_exact_limit(self):
+        content = "line1\nline2\nline3"
+        result = truncate_content(content, max_lines=3)
+        assert result == content
+
+
+class TestFormatTodos:
+    def test_empty_list(self):
+        assert format_todos([]) == ""
+
+    def test_single_pending(self):
+        todos = [{"content": "Do something", "status": "pending"}]
+        assert format_todos(todos) == "⬚ Do something"
+
+    def test_single_completed(self):
+        todos = [{"content": "Done task", "status": "completed"}]
+        assert format_todos(todos) == "✅ Done task"
+
+    def test_single_in_progress(self):
+        todos = [{"content": "Working on it", "status": "in_progress"}]
+        assert format_todos(todos) == "🔄 Working on it"
+
+    def test_multiple_todos(self):
+        todos = [
+            {"content": "First", "status": "completed"},
+            {"content": "Second", "status": "in_progress"},
+            {"content": "Third", "status": "pending"},
+        ]
+        result = format_todos(todos)
+        assert "✅ First" in result
+        assert "🔄 Second" in result
+        assert "⬚ Third" in result
+
+    def test_unknown_status(self):
+        todos = [{"content": "Unknown", "status": "weird"}]
+        assert format_todos(todos) == "• Unknown"
+
+
+class TestFormatToolOutput:
+    def test_todowrite_formats_todos(self):
+        tool_input = {
+            "todos": [
+                {"content": "Task 1", "status": "completed"},
+                {"content": "Task 2", "status": "pending"},
+            ]
+        }
+        result = format_tool_output("todowrite", tool_input, "ignored")
+        assert "✅ Task 1" in result
+        assert "⬚ Task 2" in result
+
+    def test_other_tool_returns_output(self):
+        result = format_tool_output("bash", {}, "command output")
+        assert result == "command output"
+
+    def test_empty_output(self):
+        result = format_tool_output("bash", {}, "")
+        assert result == ""
+
+
+class TestFormatToolInput:
+    def test_read_file_path(self):
+        result = format_tool_input("read", {"filePath": "/path/to/file.py"})
+        assert result == "/path/to/file.py"
+
+    def test_bash_command_short(self):
+        result = format_tool_input("bash", {"command": "ls -la"})
+        assert result == "ls -la"
+
+    def test_bash_command_long_truncated(self):
+        long_cmd = "x" * 100
+        result = format_tool_input("bash", {"command": long_cmd})
+        assert len(result) == 63
+        assert result.endswith("...")
+
+    def test_grep_pattern(self):
+        result = format_tool_input("grep", {"pattern": "TODO"})
+        assert result == "TODO"
+
+    def test_glob_pattern(self):
+        result = format_tool_input("glob", {"pattern": "**/*.py"})
+        assert result == "**/*.py"
+
+    def test_task_description(self):
+        result = format_tool_input("task", {"description": "Find auth code"})
+        assert result == "Find auth code"
+
+    def test_todowrite_empty(self):
+        result = format_tool_input("todowrite", {"todos": []})
+        assert result == ""
+
+    def test_webfetch_url_short(self):
+        result = format_tool_input("webfetch", {"url": "https://example.com/page"})
+        assert result == "https://example.com/page"
+
+    def test_webfetch_url_long_truncated(self):
+        long_url = "https://example.com/" + "a" * 50
+        result = format_tool_input("webfetch", {"url": long_url})
+        assert len(result) == 53
+        assert result.endswith("...")
+
+    def test_unknown_tool_empty(self):
+        result = format_tool_input("unknown", {"foo": "bar"})
+        assert result == ""
+
+
+class TestPrintGroupCommands:
+    def test_group_start(self):
+        output = io.StringIO()
+        print_group_start("Test Title", output)
+        assert output.getvalue() == "::group::Test Title\n"
+
+    def test_group_end(self):
+        output = io.StringIO()
+        print_group_end(output)
+        assert output.getvalue() == "::endgroup::\n"
+
+
+class TestHandleToolUse:
+    def test_tool_with_output(self):
+        output = io.StringIO()
+        part = {
+            "tool": "read",
+            "state": {
+                "input": {"filePath": "/test/file.py"},
+                "output": "file contents here",
+            },
+        }
+        handle_tool_use(part, output)
+        result = output.getvalue()
+        assert "::group::📄 Read: /test/file.py" in result
+        assert "file contents here" in result
+        assert "::endgroup::" in result
+
+    def test_tool_without_output(self):
+        output = io.StringIO()
+        part = {"tool": "todoread", "state": {"input": {}, "output": ""}}
+        handle_tool_use(part, output)
+        result = output.getvalue()
+        assert "::group::📋 Todoread" in result
+        assert "::endgroup::" in result
+
+    def test_unknown_tool(self):
+        output = io.StringIO()
+        part = {
+            "tool": "custom_tool",
+            "state": {"input": {"data": "test"}, "output": "result"},
+        }
+        handle_tool_use(part, output)
+        result = output.getvalue()
+        assert "🔧" in result
+        assert "Custom Tool" in result
+
+    def test_legacy_format_fallback(self):
+        output = io.StringIO()
+        part = {"name": "read", "input": {"filePath": "/test/file.py"}}
+        handle_tool_use(part, output)
+        result = output.getvalue()
+        assert "::group::📄 Read: /test/file.py" in result
+
+
+class TestHandleToolResult:
+    def test_result_with_content(self):
+        output = io.StringIO()
+        part = {"content": "File contents here"}
+        handle_tool_result(part, output)
+        result = output.getvalue()
+        assert "---" in result
+        assert "File contents here" in result
+        assert "::endgroup::" in result
+
+    def test_result_empty_content(self):
+        output = io.StringIO()
+        part = {"content": ""}
+        handle_tool_result(part, output)
+        result = output.getvalue()
+        assert "---" not in result
+        assert "::endgroup::" in result
+
+
+class TestHandleText:
+    def test_text_with_content(self):
+        output = io.StringIO()
+        part = {"text": "Agent response here"}
+        handle_text(part, output)
+        assert output.getvalue() == "Agent response here\n"
+
+    def test_text_whitespace_only(self):
+        output = io.StringIO()
+        part = {"text": "   \n  "}
+        handle_text(part, output)
+        assert output.getvalue() == ""
+
+    def test_text_empty(self):
+        output = io.StringIO()
+        part = {"text": ""}
+        handle_text(part, output)
+        assert output.getvalue() == ""
+
+
+class TestProcessEvent:
+    def test_tool_use_event(self):
+        output = io.StringIO()
+        event = {
+            "type": "tool_use",
+            "part": {"name": "bash", "input": {"command": "echo hello"}},
+        }
+        process_event(event, output)
+        assert "::group::" in output.getvalue()
+
+    def test_tool_result_event(self):
+        output = io.StringIO()
+        event = {"type": "tool_result", "part": {"content": "hello"}}
+        process_event(event, output)
+        assert "::endgroup::" in output.getvalue()
+
+    def test_text_event(self):
+        output = io.StringIO()
+        event = {"type": "text", "part": {"text": "Response"}}
+        process_event(event, output)
+        assert "Response" in output.getvalue()
+
+    def test_unknown_event_type_passthrough(self):
+        output = io.StringIO()
+        event = {"type": "unknown_event", "part": {"data": "test"}}
+        process_event(event, output)
+        result = output.getvalue()
+        assert "unknown_event" in result
+        assert "test" in result
+
+    def test_step_start_skipped(self):
+        output = io.StringIO()
+        event = {"type": "step_start", "part": {"id": "123"}}
+        process_event(event, output)
+        assert output.getvalue() == ""
+
+    def test_step_finish_skipped(self):
+        output = io.StringIO()
+        event = {"type": "step_finish", "part": {"id": "123"}}
+        process_event(event, output)
+        assert output.getvalue() == ""
+
+
+class TestProcessStream:
+    def test_multiple_events(self):
+        stream = io.StringIO(
+            '{"type":"tool_use","part":{"name":"read","input":{"filePath":"test.py"}}}\n'
+            '{"type":"tool_result","part":{"content":"file content"}}\n'
+            '{"type":"text","part":{"text":"Done"}}\n'
+        )
+        output = io.StringIO()
+        process_stream(stream, output)
+        result = output.getvalue()
+        assert "::group::" in result
+        assert "::endgroup::" in result
+        assert "Done" in result
+
+    def test_empty_lines_skipped(self):
+        stream = io.StringIO('\n\n{"type":"text","part":{"text":"Hello"}}\n\n')
+        output = io.StringIO()
+        process_stream(stream, output)
+        assert "Hello" in output.getvalue()
+
+    def test_invalid_json_passthrough(self):
+        stream = io.StringIO("not json\n")
+        output = io.StringIO()
+        process_stream(stream, output)
+        assert "not json" in output.getvalue()
+
+    def test_mixed_valid_invalid(self):
+        stream = io.StringIO(
+            'plain text line\n{"type":"text","part":{"text":"Valid JSON"}}\n'
+        )
+        output = io.StringIO()
+        process_stream(stream, output)
+        result = output.getvalue()
+        assert "plain text line" in result
+        assert "Valid JSON" in result


### PR DESCRIPTION
opencode JSON output is difficult to read in GitHub Actions logs due to the streaming nature and lack of structure. The raw JSON events blend together making it hard to identify individual tool calls and their results.

Add format_output.py that parses opencode's JSON format and outputs GitHub Actions workflow commands for better log organization. Tool calls become collapsible sections with icons, and long outputs are truncated to keep logs scannable. run.sh now uses the formatter automatically when GITHUB_ACTIONS=true.