### PR TITLE
fix(action): use correct endpoint for reaction deletion

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -522,7 +522,7 @@ runs:
           --jq '.[] | select(.content == "eyes") | .id' | head -1)
 
         if [[ -n "$REACTION_ID" ]]; then
-          gh api -X DELETE "/repos/$REPO/reactions/$REACTION_ID" || true
+          gh api -X DELETE "$ENDPOINT/$REACTION_ID" || true
         fi
 
         if [[ "${{ steps.agent.outputs.exit_code }}" != "0" ]]; then


### PR DESCRIPTION
The reaction deletion was using /repos/{owner}/{repo}/reactions/{id} which doesn't exist, causing a 404. GitHub requires deleting reactions from the comment's reaction endpoint:
- /repos/{owner}/{repo}/issues/comments/{id}/reactions/{reaction_id}
- /repos/{owner}/{repo}/pulls/comments/{id}/reactions/{reaction_id}

Use $ENDPOINT which already has the correct path prefix.