### PR TITLE
feat(scripts): suppress verbose output for read/glob/grep tools

### DIFF
--- a/scripts/format_output.py
+++ b/scripts/format_output.py
@@ -99,10 +99,15 @@ def format_todos(todos: list) -> str:
     return "\n".join(lines)
 
 
+SUPPRESS_OUTPUT_TOOLS = {"read", "glob", "grep"}
+
+
 def format_tool_output(tool_name: str, tool_input: dict, tool_output: str) -> str:
     name_lower = tool_name.lower()
 
-    if name_lower == "todowrite":
+    if name_lower in SUPPRESS_OUTPUT_TOOLS:
+        return ""
+    elif name_lower == "todowrite":
         todos = tool_input.get("todos", [])
         if todos:
             return format_todos(todos)


### PR DESCRIPTION
## Summary

- Suppress file contents and search results in GHA logs for `read`, `glob`, and `grep` tools
- Only shows the group title (file path or pattern); body is hidden
- Other tools (webfetch, bash, todowrite) still show full output

Reduces log noise without losing useful context - you can still see which files were read and what patterns were searched.