### PR TITLE
feat(action): add per-skill enable inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ See [`examples/agent.yaml`](./examples/agent.yaml) for a complete workflow with 
 | `auth_json` | - | Full auth.json content (advanced) |
 | `agent_keywords` | `ultrawork` | Keywords to prepend for agent mode (triggers oh-my-opencode modes) |
 | `review_keywords` | `analyze` | Keywords to prepend for review mode (triggers oh-my-opencode modes) |
+| `skill_enable_git_master` | `false` | Enable git-master builtin skill (true/false) |
+| `skill_enable_playwright` | `false` | Enable playwright builtin skill (true/false) |
+| `skill_enable_frontend_ui_ux` | `false` | Enable frontend-ui-ux builtin skill (true/false) |
 | `format_output` | `true` | Format output with collapsible sections for GitHub Actions logs |
 
 ## How It Works

--- a/action.yaml
+++ b/action.yaml
@@ -108,6 +108,21 @@ inputs:
     required: false
     default: "false"
 
+  skill_enable_git_master:
+    description: Enable git-master builtin skill (true/false)
+    required: false
+    default: "false"
+
+  skill_enable_playwright:
+    description: Enable playwright builtin skill (true/false)
+    required: false
+    default: "false"
+
+  skill_enable_frontend_ui_ux:
+    description: Enable frontend-ui-ux builtin skill (true/false)
+    required: false
+    default: "false"
+
   format_output:
     description: Format output with collapsible sections for GitHub Actions logs
     required: false
@@ -464,6 +479,9 @@ runs:
         FAST_MODEL: ${{ inputs.fast_model }}
         COMMIT_FOOTER: ${{ inputs.commit_footer }}
         INCLUDE_CO_AUTHORED_BY: ${{ inputs.include_co_authored_by }}
+        SKILL_ENABLE_GIT_MASTER: ${{ inputs.skill_enable_git_master }}
+        SKILL_ENABLE_PLAYWRIGHT: ${{ inputs.skill_enable_playwright }}
+        SKILL_ENABLE_FRONTEND_UI_UX: ${{ inputs.skill_enable_frontend_ui_ux }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
     # === RUN AGENT ===

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -48,6 +48,9 @@ def generate_omo_config(
     fast_override: str | None,
     commit_footer: str | None = None,
     include_co_authored_by: str | None = None,
+    enable_git_master: str | None = None,
+    enable_playwright: str | None = None,
+    enable_frontend_ui_ux: str | None = None,
 ) -> dict:
     models = PRESETS.get(preset, PRESETS["balanced"]).copy()
 
@@ -66,7 +69,18 @@ def generate_omo_config(
     for agent in FAST_AGENTS:
         agents[agent] = {"model": models["fast"]}
 
-    config = {"agents": agents}
+    config: dict[str, object] = {"agents": agents}
+
+    disabled_skills = []
+    if enable_git_master != "true":
+        disabled_skills.append("git-master")
+    if enable_playwright != "true":
+        disabled_skills.append("playwright")
+    if enable_frontend_ui_ux != "true":
+        disabled_skills.append("frontend-ui-ux")
+
+    if disabled_skills:
+        config["disabled_skills"] = disabled_skills
 
     git_master = {}
     if commit_footer is not None:
@@ -103,6 +117,9 @@ def main():
     fast_override = os.environ.get("FAST_MODEL")
     commit_footer = os.environ.get("COMMIT_FOOTER")
     include_co_authored_by = os.environ.get("INCLUDE_CO_AUTHORED_BY")
+    enable_git_master = os.environ.get("SKILL_ENABLE_GIT_MASTER")
+    enable_playwright = os.environ.get("SKILL_ENABLE_PLAYWRIGHT")
+    enable_frontend_ui_ux = os.environ.get("SKILL_ENABLE_FRONTEND_UI_UX")
 
     auth_dir = Path.home() / ".local" / "share" / "opencode"
     auth_dir.mkdir(parents=True, exist_ok=True)
@@ -162,6 +179,9 @@ def main():
             fast_override,
             commit_footer,
             include_co_authored_by,
+            enable_git_master,
+            enable_playwright,
+            enable_frontend_ui_ux,
         )
         omo_file.write_text(json.dumps(omo_config, indent=2))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -109,3 +109,39 @@ class TestGenerateOmoConfig:
     def test_git_master_config_none(self):
         result = generate_omo_config("balanced", None, None, None)
         assert "git_master" not in result
+
+    def test_builtin_skills_default_disabled(self):
+        result = generate_omo_config("balanced", None, None, None)
+        assert result["disabled_skills"] == [
+            "git-master",
+            "playwright",
+            "frontend-ui-ux",
+        ]
+
+    def test_builtin_skills_all_enabled(self):
+        result = generate_omo_config(
+            "balanced",
+            None,
+            None,
+            None,
+            None,
+            None,
+            "true",
+            "true",
+            "true",
+        )
+        assert "disabled_skills" not in result
+
+    def test_builtin_skills_partial_enabled(self):
+        result = generate_omo_config(
+            "balanced",
+            None,
+            None,
+            None,
+            None,
+            None,
+            "true",
+            None,
+            "true",
+        )
+        assert result["disabled_skills"] == ["playwright"]


### PR DESCRIPTION
Action runs now disable builtin skills by default, but teams need to opt into specific skills. Add per-skill inputs and wire them into generated oh-my-opencode config to omit only the enabled skills from disabled_skills.