### PR TITLE
feat(action): add provider allow/deny inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ See [`examples/agent.yaml`](./examples/agent.yaml) for a complete workflow with 
 | `opencode_version` | `latest` | OpenCode version to install |
 | `oh_my_opencode_version` | `latest` | oh-my-opencode version to install |
 | `config_json` | - | Full opencode.json content (advanced) |
+| `enabled_providers` | - | JSON array of provider IDs to enable |
+| `disabled_providers` | - | JSON array of provider IDs to disable |
 | `omo_config_json` | - | Full oh-my-opencode.json content (advanced) |
 | `auth_json` | - | Full auth.json content (advanced) |
 | `agent_keywords` | `ultrawork` | Keywords to prepend for agent mode (triggers oh-my-opencode modes) |

--- a/action.yaml
+++ b/action.yaml
@@ -82,6 +82,12 @@ inputs:
   config_json:
     description: Full opencode.json content (advanced, overrides all config)
     required: false
+  enabled_providers:
+    description: JSON array of provider IDs to enable
+    required: false
+  disabled_providers:
+    description: JSON array of provider IDs to disable
+    required: false
   omo_config_json:
     description: Full oh-my-opencode.json content (advanced, overrides presets)
     required: false
@@ -467,6 +473,8 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         AUTH_JSON: ${{ inputs.auth_json }}
         CONFIG_JSON: ${{ inputs.config_json }}
+        ENABLED_PROVIDERS: ${{ inputs.enabled_providers }}
+        DISABLED_PROVIDERS: ${{ inputs.disabled_providers }}
         OMO_CONFIG_JSON: ${{ inputs.omo_config_json }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}


### PR DESCRIPTION
Expose enabled_providers and disabled_providers inputs so workflows can allowlist or block providers without supplying full config_json overrides. Update config generation to validate provider lists, merge them into opencode.json, and document the new inputs.