### PR TITLE
fix(scripts): merge omo config json

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -204,7 +204,18 @@ def main():
         config_file.write_text(json.dumps(merged_config, indent=2))
 
     if omo_config_json:
-        omo_file.write_text(omo_config_json)
+        try:
+            omo_override = parse_json_object(omo_config_json, "OMO_CONFIG_JSON")
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            omo_base = read_json_object(omo_file) if omo_file.exists() else {}
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        merged_omo = merge_configs(omo_base, omo_override)
+        omo_file.write_text(json.dumps(merged_omo, indent=2))
     else:
         omo_config = generate_omo_config(
             preset,


### PR DESCRIPTION
Merge OMO_CONFIG_JSON with any existing `oh-my-opencode.json` to retain defaults like disabled skills while still honoring overrides.