### PR TITLE
fix(scripts): ignore empty auth json

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -78,7 +78,7 @@ def build_auth(
     auth_json: str | None,
 ) -> dict:
     auth = generate_auth(anthropic_key, openai_key, gemini_key)
-    if auth_json is None:
+    if auth_json is None or not auth_json.strip():
         return auth
     auth_override = parse_json_object(auth_json, "AUTH_JSON")
     return merge_configs(auth, auth_override)
@@ -152,6 +152,8 @@ def main():
     openai_key = os.environ.get("OPENAI_API_KEY")
     gemini_key = os.environ.get("GEMINI_API_KEY")
     auth_json = os.environ.get("AUTH_JSON")
+    if auth_json is not None and not auth_json.strip():
+        auth_json = None
     config_json = os.environ.get("CONFIG_JSON")
     enabled_providers = os.environ.get("ENABLED_PROVIDERS")
     disabled_providers = os.environ.get("DISABLED_PROVIDERS")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,6 +74,10 @@ class TestBuildAuth:
         result = build_auth("ant", None, None, "{}")
         assert result == {"anthropic": {"type": "api", "key": "ant"}}
 
+    def test_auth_json_empty_string(self):
+        result = build_auth("ant", None, None, "")
+        assert result == {"anthropic": {"type": "api", "key": "ant"}}
+
 
 class TestParseProviderList:
     def test_valid_list(self):


### PR DESCRIPTION
GitHub Actions passes AUTH_JSON as an empty string when the input is unset, which caused config parsing to fail before auth keys were written.

Treat blank AUTH_JSON values as absent in the auth merge path so generated provider keys remain valid without requiring a separate JSON payload.