### PR TITLE
fix(scripts): add config log newline

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -12,11 +12,13 @@ OMO_CONFIG="$HOME/.config/opencode/oh-my-opencode.json"
 if [[ -f "$OPENCODE_CONFIG" ]]; then
   echo "==> $OPENCODE_CONFIG"
   cat "$OPENCODE_CONFIG"
+  echo
 fi
 
 if [[ -f "$OMO_CONFIG" ]]; then
   echo "==> $OMO_CONFIG"
   cat "$OMO_CONFIG"
+  echo
 fi
 
 if [[ -n "${GITHUB_TOKEN:-}" ]]; then


### PR DESCRIPTION
The configure step logs config files with cat, which can glue the next log line onto JSON output when the file lacks a trailing newline.

Add explicit blank lines after each config log to keep the output readable.