### PR TITLE
feat(action): add provider inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ See [`examples/agent.yaml`](./examples/agent.yaml) for a complete workflow with 
 | `anthropic_api_key` | - | Anthropic API key |
 | `openai_api_key` | - | OpenAI API key |
 | `gemini_api_key` | - | Google Gemini API key |
+| `provider_anthropic` | `max20` | Anthropic provider setting (no/yes/max20) |
+| `provider_openai` | `no` | OpenAI provider setting (no/yes) |
+| `provider_google` | `no` | Google provider setting (no/yes) |
+| `provider_copilot` | `no` | GitHub Copilot provider setting (no/yes) |
 | `anthropic_base_url` | - | Custom Anthropic API base URL (for proxies) |
 | `openai_base_url` | - | Custom OpenAI API base URL (for proxies) |
 | `model_preset` | `balanced` | Preset: `balanced`, `fast`, `powerful` |

--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,22 @@ inputs:
   gemini_api_key:
     description: Google Gemini API key
     required: false
+  provider_anthropic:
+    description: Anthropic provider setting (no/yes/max20)
+    required: false
+    default: max20
+  provider_openai:
+    description: OpenAI provider setting (no/yes)
+    required: false
+    default: "no"
+  provider_google:
+    description: Google provider setting (no/yes)
+    required: false
+    default: "no"
+  provider_copilot:
+    description: GitHub Copilot provider setting (no/yes)
+    required: false
+    default: "no"
 
   anthropic_base_url:
     description: Custom Anthropic API base URL (for proxies)
@@ -465,6 +481,10 @@ runs:
       env:
         OPENCODE_VERSION: ${{ steps.version.outputs.opencode }}
         OH_MY_OPENCODE_VERSION: ${{ steps.version.outputs.oh_my_opencode }}
+        PROVIDER_ANTHROPIC: ${{ inputs.provider_anthropic }}
+        PROVIDER_OPENAI: ${{ inputs.provider_openai }}
+        PROVIDER_GOOGLE: ${{ inputs.provider_google }}
+        PROVIDER_COPILOT: ${{ inputs.provider_copilot }}
 
     - name: Configure
       shell: bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,6 +16,7 @@ echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
 bunx "oh-my-opencode@${OH_MY_OPENCODE_VERSION:-latest}" install \
   --no-tui \
-  --claude="${CLAUDE:-max20}" \
-  --chatgpt="${CHATGPT:-no}" \
-  --gemini="${GEMINI:-no}"
+  --claude="${PROVIDER_ANTHROPIC:-max20}" \
+  --chatgpt="${PROVIDER_OPENAI:-no}" \
+  --gemini="${PROVIDER_GOOGLE:-no}" \
+  --copilot="${PROVIDER_COPILOT:-no}"


### PR DESCRIPTION
Expose provider flags as action inputs so workflows can set installer options without manual env variables. Wire the inputs into the install step and document the Anthropic tristate option alongside the other
 providers.