### PR TITLE
fix(config): remove presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,7 @@ See [`examples/agent.yaml`](./examples/agent.yaml) for a complete workflow with 
 | `provider_copilot` | `no` | GitHub Copilot provider setting (no/yes) |
 | `anthropic_base_url` | - | Custom Anthropic API base URL (for proxies) |
 | `openai_base_url` | - | Custom OpenAI API base URL (for proxies) |
-| `model_preset` | `balanced` | Preset: `balanced`, `fast`, `powerful` |
-| `primary_model` | `anthropic/claude-opus-4-5` | Override primary agent model |
-| `oracle_model` | - | Override oracle agent model |
-| `fast_model` | - | Override fast agents model |
+| `primary_model` | - | Override opencode.json model |
 | `mode` | `agent` | Prompt mode (maps to `{prompt_path}/{mode}.md`) |
 | `prompt` | - | Direct prompt text (alternative to mode) |
 | `prompt_path` | `.github/prompts` | Path to prompts directory |
@@ -169,16 +166,6 @@ Set these in Settings → Secrets and variables → Variables:
 |----------|---------|-------------|
 | `BOT_NAME` | `ai-agent` | Bot mention trigger and label prefix |
 | `BOT_LOGIN` | `github-actions[bot]` | Bot login to prevent self-triggering |
-
-### Model Presets
-
-| Preset | Primary | Oracle | Fast |
-|--------|---------|--------|------|
-| `balanced` | claude-sonnet-4-5 | claude-sonnet-4-5 | claude-haiku-4-5 |
-| `fast` | claude-haiku-4-5 | claude-haiku-4-5 | claude-haiku-4-5 |
-| `powerful` | claude-opus-4-5 | gpt-5.2 | claude-sonnet-4-5 |
-
-Override individual models with `primary_model`, `oracle_model`, `fast_model` inputs.
 
 ## Authentication
 

--- a/action.yaml
+++ b/action.yaml
@@ -52,19 +52,8 @@ inputs:
     description: Custom OpenAI API base URL (for proxies)
     required: false
 
-  model_preset:
-    description: Model preset (balanced, fast, powerful)
-    required: false
-    default: balanced
   primary_model:
-    description: Override primary agent model
-    required: false
-    default: anthropic/claude-opus-4-5
-  oracle_model:
-    description: Override oracle agent model
-    required: false
-  fast_model:
-    description: Override fast agents model (explore, librarian, etc)
+    description: Override opencode.json model
     required: false
 
   mode:
@@ -502,10 +491,7 @@ runs:
         GEMINI_API_KEY: ${{ inputs.gemini_api_key }}
         ANTHROPIC_BASE_URL: ${{ inputs.anthropic_base_url }}
         OPENAI_BASE_URL: ${{ inputs.openai_base_url }}
-        MODEL_PRESET: ${{ inputs.model_preset }}
         PRIMARY_MODEL: ${{ inputs.primary_model }}
-        ORACLE_MODEL: ${{ inputs.oracle_model }}
-        FAST_MODEL: ${{ inputs.fast_model }}
         COMMIT_FOOTER: ${{ inputs.commit_footer }}
         INCLUDE_CO_AUTHORED_BY: ${{ inputs.include_co_authored_by }}
         SKILL_ENABLE_GIT_MASTER: ${{ inputs.skill_enable_git_master }}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,8 +15,6 @@ def load_config_module():
 
 
 config = load_config_module()
-FAST_AGENTS = config.FAST_AGENTS
-PRESETS = config.PRESETS
 build_auth = config.build_auth
 generate_auth = config.generate_auth
 generate_omo_config = config.generate_omo_config
@@ -110,84 +108,39 @@ class TestParseProviderList:
 
 
 class TestGenerateOmoConfig:
-    def test_balanced_preset(self):
-        result = generate_omo_config("balanced", None, None, None)
-        agents = result["agents"]
-        assert agents["Sisyphus"]["model"] == PRESETS["balanced"]["primary"]
-        assert agents["oracle"]["model"] == PRESETS["balanced"]["oracle"]
-        for agent in FAST_AGENTS:
-            assert agents[agent]["model"] == PRESETS["balanced"]["fast"]
-
-    def test_fast_preset(self):
-        result = generate_omo_config("fast", None, None, None)
-        agents = result["agents"]
-        assert agents["Sisyphus"]["model"] == PRESETS["fast"]["primary"]
-
-    def test_powerful_preset(self):
-        result = generate_omo_config("powerful", None, None, None)
-        agents = result["agents"]
-        assert agents["Sisyphus"]["model"] == PRESETS["powerful"]["primary"]
-        assert agents["oracle"]["model"] == PRESETS["powerful"]["oracle"]
-
-    def test_unknown_preset_defaults_to_balanced(self):
-        result = generate_omo_config("nonexistent", None, None, None)
-        agents = result["agents"]
-        assert agents["Sisyphus"]["model"] == PRESETS["balanced"]["primary"]
-
-    def test_primary_override(self):
-        result = generate_omo_config("balanced", "custom/model", None, None)
-        assert result["agents"]["Sisyphus"]["model"] == "custom/model"
-
-    def test_oracle_override(self):
-        result = generate_omo_config("balanced", None, "custom/oracle", None)
-        assert result["agents"]["oracle"]["model"] == "custom/oracle"
-
-    def test_fast_override(self):
-        result = generate_omo_config("balanced", None, None, "custom/fast")
-        for agent in FAST_AGENTS:
-            assert result["agents"][agent]["model"] == "custom/fast"
-
-    def test_all_overrides(self):
-        result = generate_omo_config("balanced", "p", "o", "f")
-        agents = result["agents"]
-        assert agents["Sisyphus"]["model"] == "p"
-        assert agents["oracle"]["model"] == "o"
-        for agent in FAST_AGENTS:
-            assert agents[agent]["model"] == "f"
-
     def test_git_master_config(self):
-        result = generate_omo_config("balanced", None, None, None, "true", "true")
+        result = generate_omo_config("true", "true")
         assert result["git_master"] == {
             "commit_footer": True,
             "include_co_authored_by": True,
         }
 
     def test_git_master_config_false(self):
-        result = generate_omo_config("balanced", None, None, None, "false", "false")
+        result = generate_omo_config("false", "false")
         assert result["git_master"] == {
             "commit_footer": False,
             "include_co_authored_by": False,
         }
 
     def test_git_master_config_mixed(self):
-        result = generate_omo_config("balanced", None, None, None, "true", "false")
+        result = generate_omo_config("true", "false")
         assert result["git_master"] == {
             "commit_footer": True,
             "include_co_authored_by": False,
         }
 
     def test_git_master_config_partial(self):
-        result = generate_omo_config("balanced", None, None, None, None, "true")
+        result = generate_omo_config(None, "true")
         assert result["git_master"] == {
             "include_co_authored_by": True,
         }
 
     def test_git_master_config_none(self):
-        result = generate_omo_config("balanced", None, None, None)
+        result = generate_omo_config()
         assert "git_master" not in result
 
     def test_builtin_skills_default_disabled(self):
-        result = generate_omo_config("balanced", None, None, None)
+        result = generate_omo_config()
         assert result["disabled_skills"] == [
             "git-master",
             "playwright",
@@ -196,10 +149,6 @@ class TestGenerateOmoConfig:
 
     def test_builtin_skills_all_enabled(self):
         result = generate_omo_config(
-            "balanced",
-            None,
-            None,
-            None,
             None,
             None,
             "true",
@@ -210,10 +159,6 @@ class TestGenerateOmoConfig:
 
     def test_builtin_skills_partial_enabled(self):
         result = generate_omo_config(
-            "balanced",
-            None,
-            None,
-            None,
             None,
             None,
             "true",


### PR DESCRIPTION
Having presets negate omo generating a working agent config since it will always overwrite the agent config. Since omo now generates reasonable configs based on the install args, depend on its config generation for the agents.