### PR TITLE
fix(vars): pass comment and pr_title via env to avoid shell injection

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -283,6 +283,8 @@ runs:
         INPUT_PROMPT_VARS: ${{ inputs.prompt_vars }}
         THREADS_JSON: ${{ steps.threads.outputs.json }}
         THREADS_COUNT: ${{ steps.threads.outputs.count }}
+        COMMENT: ${{ steps.context.outputs.comment }}
+        PR_TITLE: ${{ steps.context.outputs.pr_title }}
       run: |
         CONTEXT_TYPE="${{ steps.context.outputs.context_type }}"
         DIFF_PATH="${{ steps.context.outputs.diff_path }}"
@@ -326,14 +328,14 @@ runs:
           --arg author_mention "$AUTHOR_MENTION" \
           --arg bot_name "$INPUT_BOT_NAME" \
           --arg mention_users "$INPUT_MENTION_USERS" \
-          --arg comment "${{ steps.context.outputs.comment }}" \
+          --arg comment "$COMMENT" \
           --arg comment_id "${{ steps.context.outputs.comment_id }}" \
           --arg context_type "$CONTEXT_TYPE" \
           --arg number "${{ steps.context.outputs.number }}" \
           --arg repository "${{ github.repository }}" \
           --arg default_branch "${{ github.event.repository.default_branch }}" \
           --arg pr_number "${{ steps.context.outputs.number }}" \
-          --arg pr_title "${{ steps.context.outputs.pr_title }}" \
+          --arg pr_title "$PR_TITLE" \
           --arg pr_author "$PR_AUTHOR" \
           --arg pr_author_mention "$PR_AUTHOR_MENTION" \
           --arg requested_by "$REQUESTED_BY" \


### PR DESCRIPTION
## Problem

When a PR comment body contains backticks, triple-backtick code fences, or other shell metacharacters, the `Build prompt_vars` step fails with a bash syntax error:

```
syntax error near unexpected token `('
```

This happens because `${{ steps.context.outputs.comment }}` is substituted inline into the `run:` block before the shell parses it. Backticks in the comment value are interpreted as command substitution by bash.

## Root cause

GitHub Actions performs `${{ ... }}` text substitution before handing the script to the shell. So a comment body like:

```
See `otelcol_artifact_name` at line 16
```

becomes this in the generated script:

```bash
--arg comment "See `otelcol_artifact_name` at line 16" \
```

Bash then tries to execute `otelcol_artifact_name` as a command substitution, causing a syntax error.

The same issue applies to `pr_title`, which is also user-controlled.

## Fix

Move `comment` and `pr_title` to the `env:` block (where values are safely passed as environment variables, not interpolated into script text) and reference them via `$COMMENT` / `$PR_TITLE`.

This is consistent with how `DIFF_HUNK`, `THREADS_JSON`, and other potentially complex values are already handled in the same step.