### PR TITLE
fix(action): enable logs in GitHub debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ See [`examples/agent.yaml`](./examples/agent.yaml) for a complete workflow with 
 | `skill_enable_playwright` | `false` | Enable playwright builtin skill (true/false) |
 | `skill_enable_frontend_ui_ux` | `false` | Enable frontend-ui-ux builtin skill (true/false) |
 | `format_output` | `true` | Format output with collapsible sections for GitHub Actions logs |
-| `opencode_print_logs` | `false` | Include raw opencode runtime logs (`--print-logs`) in agent runs |
+| `opencode_print_logs` | `false` | Include raw opencode runtime logs (`--print-logs`) in agent runs. GitHub debug reruns also enable this automatically. |
 
 ## How It Works
 

--- a/action.yaml
+++ b/action.yaml
@@ -156,7 +156,9 @@ inputs:
     required: false
     default: "true"
   opencode_print_logs:
-    description: Include raw opencode runtime logs (--print-logs) in agent runs
+    description: >-
+      Include raw opencode runtime logs (--print-logs) in agent runs;
+      GitHub debug reruns enable this automatically
     required: false
     default: "false"
 

--- a/scripts/format_output.py
+++ b/scripts/format_output.py
@@ -30,6 +30,24 @@ TOOL_ICONS = {
 DEFAULT_ICON = "🔧"
 
 
+def env_flag_enabled(name: str) -> bool:
+    """Return True when an environment flag is explicitly enabled."""
+    return os.environ.get(name, "").lower() in {"1", "true"}
+
+
+def should_print_logs() -> bool:
+    """Enable print-logs for explicit config or GitHub debug mode."""
+    return any(
+        env_flag_enabled(name)
+        for name in (
+            "OPENCODE_PRINT_LOGS",
+            "RUNNER_DEBUG",
+            "ACTIONS_STEP_DEBUG",
+            "ACTIONS_RUNNER_DEBUG",
+        )
+    )
+
+
 def get_tool_icon(tool_name: str) -> str:
     """Get icon for a tool, case-insensitive."""
     return TOOL_ICONS.get(tool_name.lower(), DEFAULT_ICON)
@@ -196,7 +214,7 @@ def process_stream(stream: IO[str], output: TextIO = sys.stdout) -> None:
 
 def run_opencode(prompt: str, output: TextIO = sys.stdout) -> int:
     base_cmd = ["opencode", "run"]
-    if os.environ.get("OPENCODE_PRINT_LOGS", "false").lower() == "true":
+    if should_print_logs():
         base_cmd.append("--print-logs")
     base_cmd.extend(["--format", "json", prompt])
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,6 +4,18 @@ set -uo pipefail
 ACTION_PATH="${ACTION_PATH:-.}"
 PROMPT_PATH="${PROMPT_PATH:-.github/prompts}"
 
+is_truthy() {
+  local value="${1:-}"
+  [[ "${value,,}" == "true" ]] || [[ "$value" == "1" ]]
+}
+
+should_print_logs() {
+  is_truthy "${OPENCODE_PRINT_LOGS:-false}" \
+    || is_truthy "${RUNNER_DEBUG:-}" \
+    || is_truthy "${ACTIONS_STEP_DEBUG:-false}" \
+    || is_truthy "${ACTIONS_RUNNER_DEBUG:-false}"
+}
+
 VARS_SCRIPT="$ACTION_PATH/scripts/vars.py"
 PROMPT_SCRIPT="$ACTION_PATH/scripts/prompt.py"
 SUBSTITUTE_SCRIPT="$ACTION_PATH/scripts/substitute.py"
@@ -50,8 +62,11 @@ fi
 FINAL=$("$SUBSTITUTE_SCRIPT" "$VARS" <<< "$TEMPLATE")
 FORMAT_SCRIPT="$ACTION_PATH/scripts/format_output.py"
 PRINT_LOG_ARGS=()
+PRINT_LOGS=false
 
-if [[ "${OPENCODE_PRINT_LOGS:-false}" == "true" ]]; then
+if should_print_logs; then
+  export OPENCODE_PRINT_LOGS=true
+  PRINT_LOGS=true
   PRINT_LOG_ARGS+=(--print-logs)
 fi
 
@@ -64,7 +79,7 @@ fi
 EXIT_CODE=$?
 set -e
 
-if [[ "${OPENCODE_PRINT_LOGS:-false}" == "true" ]]; then
+if [[ "$PRINT_LOGS" == "true" ]]; then
   OMO_LOG_FILE="$(python3 -c 'import tempfile; print(tempfile.gettempdir() + "/oh-my-opencode.log")')"
   if [[ -f "$OMO_LOG_FILE" ]]; then
     if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then

--- a/tests/test_format_output.py
+++ b/tests/test_format_output.py
@@ -29,6 +29,7 @@ print_group_start = format_output.print_group_start
 process_event = format_output.process_event
 process_stream = format_output.process_stream
 run_opencode = format_output.run_opencode
+should_print_logs = format_output.should_print_logs
 truncate_content = format_output.truncate_content
 
 
@@ -438,3 +439,52 @@ class TestRunOpencode:
         assert commands == [
             ["opencode", "run", "--print-logs", "--format", "json", "hello"]
         ]
+
+    def test_run_with_runner_debug(self, monkeypatch):
+        commands = []
+
+        class FakeProcess:
+            def __init__(self, cmd, **kwargs):
+                commands.append(cmd)
+                self.stdout = io.StringIO("")
+
+            def wait(self):
+                return 0
+
+        monkeypatch.delenv("OPENCODE_PRINT_LOGS", raising=False)
+        monkeypatch.setenv("RUNNER_DEBUG", "1")
+        monkeypatch.setattr(format_output.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(format_output.subprocess, "Popen", FakeProcess)
+
+        exit_code = run_opencode("hello")
+
+        assert exit_code == 0
+        assert commands == [
+            ["opencode", "run", "--print-logs", "--format", "json", "hello"]
+        ]
+
+
+class TestShouldPrintLogs:
+    def test_false_when_no_flags_set(self, monkeypatch):
+        monkeypatch.delenv("OPENCODE_PRINT_LOGS", raising=False)
+        monkeypatch.delenv("RUNNER_DEBUG", raising=False)
+        monkeypatch.delenv("ACTIONS_STEP_DEBUG", raising=False)
+        monkeypatch.delenv("ACTIONS_RUNNER_DEBUG", raising=False)
+
+        assert should_print_logs() is False
+
+    def test_true_for_actions_step_debug(self, monkeypatch):
+        monkeypatch.delenv("OPENCODE_PRINT_LOGS", raising=False)
+        monkeypatch.delenv("RUNNER_DEBUG", raising=False)
+        monkeypatch.setenv("ACTIONS_STEP_DEBUG", "true")
+        monkeypatch.delenv("ACTIONS_RUNNER_DEBUG", raising=False)
+
+        assert should_print_logs() is True
+
+    def test_true_for_actions_runner_debug(self, monkeypatch):
+        monkeypatch.delenv("OPENCODE_PRINT_LOGS", raising=False)
+        monkeypatch.delenv("RUNNER_DEBUG", raising=False)
+        monkeypatch.delenv("ACTIONS_STEP_DEBUG", raising=False)
+        monkeypatch.setenv("ACTIONS_RUNNER_DEBUG", "true")
+
+        assert should_print_logs() is True

--- a/tests/test_run_script.py
+++ b/tests/test_run_script.py
@@ -57,6 +57,51 @@ class TestRunScript:
             else:
                 log_file.write_text(original)
 
+    def test_runner_debug_enables_print_logs(self):
+        log_file = Path(tempfile.gettempdir()) / "oh-my-opencode.log"
+        original = log_file.read_text() if log_file.exists() else None
+
+        try:
+            log_file.write_text("runner debug line\n")
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                tmppath = Path(tmpdir)
+                fake_bin = tmppath / "bin"
+                fake_bin.mkdir()
+
+                fake_opencode = fake_bin / "opencode"
+                fake_opencode.write_text(
+                    "#!/bin/bash\nprintf 'fake opencode %s\\n' \"$*\"\n"
+                )
+                fake_opencode.chmod(0o755)
+
+                result = subprocess.run(
+                    ["bash", str(RUN_SCRIPT)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env={
+                        **os.environ,
+                        "ACTION_PATH": str(ACTION_PATH),
+                        "PROMPT": "Reply with the single word OK.",
+                        "PROMPT_VARS": "{}",
+                        "FORMAT_OUTPUT": "false",
+                        "RUNNER_DEBUG": "1",
+                        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                    },
+                )
+
+            assert (
+                "fake opencode run --print-logs Reply with the single word OK."
+                in result.stdout
+            )
+            assert "runner debug line" in result.stdout
+        finally:
+            if original is None:
+                log_file.unlink(missing_ok=True)
+            else:
+                log_file.write_text(original)
+
     def test_prompt_append_preserves_sisyphus_model(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmppath = Path(tmpdir)


### PR DESCRIPTION
GitHub reruns with debug logging expose runner.debug and RUNNER_DEBUG, but this action only enabled raw opencode logs when opencode_print_logs was set explicitly. That left rerun-with-debug sessions without the internal opencode and oh-my-opencode details needed to diagnose failures.

Teach the shell runner and formatted output path to treat GitHub debug mode as an implicit request for --print-logs, and document the behavior in the action input and README. Keep the existing manual input so callers can still force verbose logs outside debug reruns.