### PR TITLE
fix(action): keep reviews read-only

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -559,7 +559,7 @@ runs:
 
     # === TEARDOWN (always runs) ===
     - name: Replay commits as signed
-      if: always() && steps.agent.outputs.exit_code == '0'
+      if: always() && steps.agent.outputs.exit_code == '0' && steps.mode.outputs.value != 'review'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
@@ -580,8 +580,19 @@ runs:
         REPO="${{ github.repository }}"
         RUN_ID="${{ github.run_id }}"
         RUN_URL="$SERVER/$REPO/actions/runs/$RUN_ID"
-        gh issue comment "${{ steps.context.outputs.number }}" \
-          --body "Agent encountered an error. [View logs]($RUN_URL)"
+
+        ERROR_SUMMARY=""
+        if [[ -f .dobbyphus-state.json ]]; then
+          ERROR_SUMMARY=$(jq -r '.error_summary // ""' .dobbyphus-state.json)
+        fi
+
+        if [[ -n "$ERROR_SUMMARY" ]]; then
+          BODY="Agent encountered an error: $ERROR_SUMMARY [View logs]($RUN_URL)"
+        else
+          BODY="Agent encountered an error. [View logs]($RUN_URL)"
+        fi
+
+        gh issue comment "${{ steps.context.outputs.number }}" --body "$BODY"
 
     - name: Update reaction
       if: always() && steps.context.outputs.comment_id != ''

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,7 +6,9 @@ PROMPT_PATH="${PROMPT_PATH:-.github/prompts}"
 
 is_truthy() {
   local value="${1:-}"
-  [[ "${value,,}" == "true" ]] || [[ "$value" == "1" ]]
+  local lowered
+  lowered=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
+  [[ "$lowered" == "true" ]] || [[ "$value" == "1" ]]
 }
 
 should_print_logs() {
@@ -63,6 +65,23 @@ FINAL=$("$SUBSTITUTE_SCRIPT" "$VARS" <<< "$TEMPLATE")
 FORMAT_SCRIPT="$ACTION_PATH/scripts/format_output.py"
 PRINT_LOG_ARGS=()
 PRINT_LOGS=false
+RUN_LOG="$(mktemp -t dobbyphus-run.XXXXXX)"
+
+provider_error_summary() {
+  local log_file="$1"
+
+  if grep -Eiq 'credit balance|insufficient[_ ]quota' "$log_file"; then
+    printf '%s\n' 'LLM provider quota or credit check failed.'
+    return 0
+  fi
+
+  if grep -Eiq 'invalid x-api-key|incorrect api key|api key[^[:cntrl:]]*invalid' "$log_file"; then
+    printf '%s\n' 'LLM provider API key authentication failed.'
+    return 0
+  fi
+
+  return 1
+}
 
 if should_print_logs; then
   export OPENCODE_PRINT_LOGS=true
@@ -72,12 +91,28 @@ fi
 
 set +e
 if [[ "${FORMAT_OUTPUT:-true}" == "true" ]] && [[ "${GITHUB_ACTIONS:-}" == "true" ]] && [[ -f "$FORMAT_SCRIPT" ]]; then
-  python3 "$FORMAT_SCRIPT" "$FINAL"
+  python3 "$FORMAT_SCRIPT" "$FINAL" 2> >(tee "$RUN_LOG" >&2)
+  EXIT_CODE=$?
 else
-  opencode run "${PRINT_LOG_ARGS[@]}" "$FINAL"
+  if [[ "$PRINT_LOGS" == "true" ]]; then
+    opencode run --print-logs "$FINAL" 2> >(tee "$RUN_LOG" >&2)
+  else
+    opencode run "$FINAL" 2> >(tee "$RUN_LOG" >&2)
+  fi
+  EXIT_CODE=$?
 fi
-EXIT_CODE=$?
 set -e
+
+ERROR_SUMMARY=""
+if ERROR_SUMMARY=$(provider_error_summary "$RUN_LOG"); then
+  jq -n --arg summary "$ERROR_SUMMARY" \
+    '{error_summary: $summary, failed: true}' > .dobbyphus-state.json
+  if [[ $EXIT_CODE -eq 0 ]]; then
+    EXIT_CODE=1
+  fi
+fi
+
+rm -f "$RUN_LOG"
 
 if [[ "$PRINT_LOGS" == "true" ]]; then
   OMO_LOG_FILE="$(python3 -c 'import tempfile; print(tempfile.gettempdir() + "/oh-my-opencode.log")')"
@@ -99,4 +134,4 @@ if [[ $EXIT_CODE -ne 0 ]]; then
   fi
 fi
 
-exit $EXIT_CODE
+exit "$EXIT_CODE"

--- a/tests/test_run_script.py
+++ b/tests/test_run_script.py
@@ -154,3 +154,39 @@ class TestRunScript:
             assert data["agents"]["sisyphus"]["variant"] == "max"
             assert "prompt_append" in data["agents"]["sisyphus"]
             assert "Sisyphus" not in data["agents"]
+
+    def test_provider_error_output_fails_run(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            fake_bin = tmppath / "bin"
+            fake_bin.mkdir()
+
+            fake_opencode = fake_bin / "opencode"
+            fake_opencode.write_text(
+                "#!/bin/bash\n"
+                "printf 'APIError: Your credit balance is too low to access the Anthropic API.\\n' >&2\n"
+            )
+            fake_opencode.chmod(0o755)
+
+            result = subprocess.run(
+                ["bash", str(RUN_SCRIPT)],
+                check=False,
+                capture_output=True,
+                text=True,
+                cwd=tmppath,
+                env={
+                    **os.environ,
+                    "ACTION_PATH": str(ACTION_PATH),
+                    "PROMPT": "Reply with the single word OK.",
+                    "PROMPT_VARS": "{}",
+                    "FORMAT_OUTPUT": "false",
+                    "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                },
+            )
+
+            assert result.returncode == 1
+            state = json.loads((tmppath / ".dobbyphus-state.json").read_text())
+            assert (
+                state["error_summary"] == "LLM provider quota or credit check failed."
+            )
+            assert state["failed"] is True


### PR DESCRIPTION
## Summary
- skip signed commit replay for review-mode runs so review requests cannot create follow-up PRs
- fail runs on definitive provider/API failure strings emitted on runner stderr
- include a short redacted provider/runtime summary in the existing failure comment path

## Why
Review requests should only review. The previous behavior allowed a successful review-mode run to replay local commits and open a new PR. Provider/API failures could also leave the trigger without a useful failure comment.

## Validation
- `yamllint .`
- `uvx ruff check scripts/ tests/`
- `uvx ruff format scripts/ tests/ --check`
- `shellcheck scripts/*.sh`
- `PYTHONDONTWRITEBYTECODE=1 pytest tests/ -v`