### PR TITLE
fix(action): make runtime auditable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See [`examples/agent.yaml`](./examples/agent.yaml) for a complete workflow with 
 | Input | Default | Description |
 |-------|---------|-------------|
 | `bot_name` | `ai-agent` | Bot name for labels and mentions |
-| `bot_login` | `""` | Optional GitHub login expected to author review output; use when review verification cannot infer it from the event |
+| `bot_login` | `""` | Review author login; required for `pull_request` review events when it cannot be inferred |
 | `mention_users` | `false` | Whether to @mention users in comments (reduces notification noise when false) |
 | `anthropic_api_key` | - | Anthropic API key |
 | `openai_api_key` | - | OpenAI API key |
@@ -174,9 +174,9 @@ Set these in Settings → Secrets and variables → Variables:
 | `BOT_NAME` | `ai-agent` | Bot mention trigger and label prefix |
 | `BOT_LOGIN` | `github-actions[bot]` | Bot login to prevent self-triggering |
 
-If hosted review verification cannot infer the review author from the event,
-pass `bot_login` explicitly so the action can verify that review mode posted a
-new PR review.
+`pull_request` review events do not identify the review author. Pass
+`bot_login` explicitly so the action can verify that review mode posted a new
+PR review.
 
 ## Authentication
 

--- a/action.yaml
+++ b/action.yaml
@@ -21,8 +21,8 @@ inputs:
 
   bot_login:
     description: >-
-      Optional GitHub login expected to author review output; use when
-      automatic detection is unavailable for review verification
+      GitHub login expected to author review output; required for pull_request
+      review events when automatic detection is unavailable
     required: false
     default: ""
 
@@ -473,6 +473,7 @@ runs:
       if: >-
         steps.mode.outputs.value == 'review' &&
         (steps.context.outputs.context_type == 'pr_comment' ||
+         steps.context.outputs.context_type == 'pr_opened' ||
          steps.context.outputs.context_type == 'pr_review_request')
       shell: bash
       env:
@@ -498,6 +499,7 @@ runs:
         steps.actor.outputs.login != '' &&
         steps.mode.outputs.value == 'review' &&
         (steps.context.outputs.context_type == 'pr_comment' ||
+         steps.context.outputs.context_type == 'pr_opened' ||
          steps.context.outputs.context_type == 'pr_review_request')
       shell: bash
       env:
@@ -554,6 +556,7 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/scripts/install.sh
       env:
+        GH_TOKEN: ${{ inputs.github_token }}
         OPENCODE_VERSION: ${{ steps.version.outputs.opencode }}
         OH_MY_OPENCODE_VERSION: ${{ steps.version.outputs.oh_my_opencode }}
         PROVIDER_ANTHROPIC: ${{ inputs.provider_anthropic }}
@@ -582,6 +585,7 @@ runs:
         PROVIDER_ZAI_CODING_PLAN: ${{ inputs.provider_zai_coding_plan }}
         PROVIDER_KIMI_FOR_CODING: ${{ inputs.provider_kimi_for_coding }}
         PROVIDER_OPENCODE_GO: ${{ inputs.provider_opencode_go }}
+        OH_MY_OPENCODE_VERSION: ${{ steps.version.outputs.oh_my_opencode }}
         OMO_CONFIG_JSON: ${{ inputs.omo_config_json }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
@@ -626,12 +630,15 @@ runs:
         steps.agent.outputs.exit_code == '0' &&
         steps.mode.outputs.value == 'review' &&
         (steps.context.outputs.context_type == 'pr_comment' ||
+         steps.context.outputs.context_type == 'pr_opened' ||
          steps.context.outputs.context_type == 'pr_review_request')
       shell: bash
       env:
+        BOT_LOGIN: ${{ steps.actor.outputs.login }}
+        CONTEXT_TYPE: ${{ steps.context.outputs.context_type }}
         GH_TOKEN: ${{ inputs.github_token }}
       run: |
-        if [[ -z "${{ steps.actor.outputs.login }}" ]]; then
+        if [[ -z "$BOT_LOGIN" ]]; then
           SUMMARY="Review output verification could not determine the "
           SUMMARY+="review author login for this trigger. Set bot_login "
           SUMMARY+="to enable verification for this review context."
@@ -658,8 +665,8 @@ runs:
 
         set +e
         VERIFY_OUTPUT=$(python3 "${{ github.action_path }}/scripts/verify_review_output.py" \
-          "${{ steps.actor.outputs.login }}" \
-          "${{ steps.context.outputs.context_type }}" \
+          "$BOT_LOGIN" \
+          "$CONTEXT_TYPE" \
           "${{ steps.review_baseline.outputs.path }}" \
           "$REVIEWS_AFTER" 2>&1)
         VERIFY_EXIT=$?

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -167,6 +167,22 @@ def merge_configs(base: dict, override: dict) -> dict:
     return merged
 
 
+def pin_omo_plugin(config: dict, version: str | None) -> dict:
+    if not version or not isinstance(config.get("plugin"), list):
+        return config
+
+    pinned = config.copy()
+    package_version = version.removeprefix("v")
+    pinned["plugin"] = [
+        f"{entry.split('@', 1)[0]}@{package_version}"
+        if isinstance(entry, str)
+        and entry.split("@", 1)[0] in {"oh-my-opencode", "oh-my-openagent"}
+        else entry
+        for entry in config["plugin"]
+    ]
+    return pinned
+
+
 def main():
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     openai_key = os.environ.get("OPENAI_API_KEY")
@@ -175,6 +191,7 @@ def main():
     if auth_json is not None and not auth_json.strip():
         auth_json = None
     config_json = os.environ.get("CONFIG_JSON")
+    omo_version = os.environ.get("OH_MY_OPENCODE_VERSION")
     enabled_providers = os.environ.get("ENABLED_PROVIDERS")
     disabled_providers = os.environ.get("DISABLED_PROVIDERS")
     provider_settings = {
@@ -240,7 +257,7 @@ def main():
     if provider_overrides:
         override_config = merge_configs(override_config, provider_overrides)
 
-    merged_config = base_config
+    merged_config = pin_omo_plugin(base_config, omo_version)
     if primary_override:
         merged_config = merge_configs(merged_config, {"model": primary_override})
     if override_config:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,20 +1,113 @@
 #!/bin/bash
 set -euo pipefail
 
+opencode_asset_name() {
+  local os arch target extension
+
+  case "$(uname -s)" in
+    Darwin*) os="darwin" ;;
+    Linux*) os="linux" ;;
+    MINGW* | MSYS* | CYGWIN*) os="windows" ;;
+    *) echo "Unsupported operating system: $(uname -s)" >&2; return 1 ;;
+  esac
+
+  arch=$(uname -m)
+  [[ "$arch" == "aarch64" ]] && arch="arm64"
+  [[ "$arch" == "x86_64" ]] && arch="x64"
+
+  if [[ "$os" == "darwin" && "$arch" == "x64" ]] \
+    && [[ "$(sysctl -n sysctl.proc_translated 2>/dev/null || echo 0)" == "1" ]]; then
+    arch="arm64"
+  fi
+
+  case "$os-$arch" in
+    linux-x64 | linux-arm64 | darwin-x64 | darwin-arm64 | windows-x64) ;;
+    *) echo "Unsupported OS/architecture: $os/$arch" >&2; return 1 ;;
+  esac
+
+  target="$os-$arch"
+  extension=".zip"
+  [[ "$os" == "linux" ]] && extension=".tar.gz"
+
+  if [[ "$arch" == "x64" ]]; then
+    if [[ "$os" == "linux" ]] && ! grep -qwi avx2 /proc/cpuinfo 2>/dev/null; then
+      target+="-baseline"
+    elif [[ "$os" == "darwin" ]] \
+      && [[ "$(sysctl -n hw.optional.avx2_0 2>/dev/null || echo 0)" != "1" ]]; then
+      target+="-baseline"
+    fi
+  fi
+
+  if [[ "$os" == "linux" ]] \
+    && { [[ -f /etc/alpine-release ]] || ldd --version 2>&1 | grep -qi musl; }; then
+    target+="-musl"
+  fi
+
+  printf 'opencode-%s%s\n' "$target" "$extension"
+}
+
+install_opencode() {
+  local asset release release_tag url digest expected actual tmp_dir archive
+
+  asset=$(opencode_asset_name)
+  release_tag="$OPENCODE_VERSION"
+  [[ "$release_tag" == v* ]] || release_tag="v$release_tag"
+  release=$(gh api "repos/anomalyco/opencode/releases/tags/$release_tag")
+  url=$(jq -r --arg asset "$asset" \
+    '.assets[] | select(.name == $asset) | .browser_download_url' <<< "$release")
+  digest=$(jq -r --arg asset "$asset" \
+    '.assets[] | select(.name == $asset) | .digest' <<< "$release")
+
+  if [[ -z "$url" || "$url" == "null" || "$digest" != sha256:* ]]; then
+    echo "Release $release_tag has no verified $asset asset" >&2
+    return 1
+  fi
+
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "$tmp_dir"' RETURN
+  archive="$tmp_dir/$asset"
+  curl -fsSL "$url" -o "$archive"
+
+  expected="${digest#sha256:}"
+  if command -v sha256sum &>/dev/null; then
+    actual=$(sha256sum "$archive")
+  elif command -v shasum &>/dev/null; then
+    actual=$(shasum -a 256 "$archive")
+  else
+    echo "No SHA-256 checksum tool found" >&2
+    return 1
+  fi
+  actual="${actual%% *}"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Checksum verification failed for $asset" >&2
+    return 1
+  fi
+
+  if [[ "$asset" == *.tar.gz ]]; then
+    tar -xzf "$archive" -C "$tmp_dir"
+  else
+    unzip -q "$archive" -d "$tmp_dir"
+  fi
+
+  mkdir -p "$HOME/.opencode/bin"
+  install -m 0755 "$tmp_dir/opencode" "$HOME/.opencode/bin/opencode"
+}
+
 if [[ "$(uname -s)" == "Linux" ]] && ! command -v tmux &>/dev/null; then
   sudo apt-get update -qq
   sudo apt-get install -y -qq --no-install-recommends tmux
 fi
 
 if [[ ! -x "$HOME/.opencode/bin/opencode" ]]; then
-  curl -fsSL https://opencode.ai/install | bash -s -- --version "${OPENCODE_VERSION}"
+  install_opencode
 fi
 
 # Add to current PATH (GITHUB_PATH only affects subsequent steps)
 export PATH="$HOME/.opencode/bin:$PATH"
 echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
-bunx "oh-my-opencode@${OH_MY_OPENCODE_VERSION:-latest}" install \
+OMO_VERSION="${OH_MY_OPENCODE_VERSION:-latest}"
+env -u GH_TOKEN bunx "oh-my-opencode@${OMO_VERSION#v}" install \
   --no-tui \
   --claude="${PROVIDER_ANTHROPIC:-max20}" \
   --openai="${PROVIDER_OPENAI:-no}" \
@@ -24,3 +117,6 @@ bunx "oh-my-opencode@${OH_MY_OPENCODE_VERSION:-latest}" install \
   --zai-coding-plan="${PROVIDER_ZAI_CODING_PLAN:-no}" \
   --kimi-for-coding="${PROVIDER_KIMI_FOR_CODING:-no}" \
   --opencode-go="${PROVIDER_OPENCODE_GO:-no}"
+
+echo "OpenCode version: $(opencode --version)"
+echo "oh-my-opencode version: ${OMO_VERSION#v}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,6 +3,7 @@ set -uo pipefail
 
 ACTION_PATH="${ACTION_PATH:-.}"
 PROMPT_PATH="${PROMPT_PATH:-.github/prompts}"
+OMO_FILE="$HOME/.config/opencode/oh-my-opencode.json"
 
 is_truthy() {
   local value="${1:-}"
@@ -34,12 +35,20 @@ for base in github_env comment_formatting file_changes; do
 done
 
 if [[ -n "$PROMPT_APPEND" ]]; then
-  OMO_FILE="$HOME/.config/opencode/oh-my-opencode.json"
   if [[ -f "$OMO_FILE" ]]; then
     jq --arg append "$PROMPT_APPEND" \
       '.agents.sisyphus = ((.agents.sisyphus // {}) + {prompt_append: $append})' \
       "$OMO_FILE" > "${OMO_FILE}.tmp" && mv "${OMO_FILE}.tmp" "$OMO_FILE"
   fi
+fi
+
+if [[ -f "$OMO_FILE" ]]; then
+  jq -r '
+    .agents.sisyphus
+    | select(type == "object" and (.model | type == "string"))
+    | (.model | split("/")) as $model
+    | "Runtime config: agent=sisyphus provider=\($model[0]) model=\($model[1:] | join("/")) variant=\(.variant // "default")"
+  ' "$OMO_FILE"
 fi
 
 if [[ -n "${PROMPT:-}" ]]; then

--- a/scripts/verify_review_output.py
+++ b/scripts/verify_review_output.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 
-REVIEW_CONTEXT_TYPES = {"pr_comment", "pr_review_request"}
+REVIEW_CONTEXT_TYPES = {"pr_comment", "pr_opened", "pr_review_request"}
 
 
 def load_reviews(path: Path) -> list[dict]:

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -8,7 +8,8 @@ else
 fi
 
 if [[ "${OH_MY_OPENCODE_VERSION:-latest}" == "latest" ]]; then
-  OMO=$(gh api repos/code-yeongyu/oh-my-openagent/releases/latest --jq '.tag_name')
+  OMO="v$(curl -fsSL https://registry.npmjs.org/oh-my-opencode/latest \
+    | jq -er '.version')"
 else
   OMO="${OH_MY_OPENCODE_VERSION}"
 fi

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 if [[ "${OPENCODE_VERSION:-latest}" == "latest" ]]; then
-  OPENCODE=$(gh api repos/sst/opencode/releases/latest --jq '.tag_name')
+  OPENCODE=$(gh api repos/anomalyco/opencode/releases/latest --jq '.tag_name')
 else
   OPENCODE="${OPENCODE_VERSION}"
 fi
 
 if [[ "${OH_MY_OPENCODE_VERSION:-latest}" == "latest" ]]; then
-  OMO=$(gh api repos/code-yeongyu/oh-my-opencode/releases/latest --jq '.tag_name')
+  OMO=$(gh api repos/code-yeongyu/oh-my-openagent/releases/latest --jq '.tag_name')
 else
   OMO="${OH_MY_OPENCODE_VERSION}"
 fi

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,7 @@ parse_provider_list = config.parse_provider_list
 derive_provider_lists = config.derive_provider_lists
 provider_enabled = config.provider_enabled
 build_provider_overrides = config.build_provider_overrides
+pin_omo_plugin = config.pin_omo_plugin
 
 
 def assert_value_error(expected: str, func, *args):
@@ -289,3 +290,21 @@ class TestGenerateOmoConfig:
             "true",
         )
         assert result["disabled_skills"] == ["playwright"]
+
+
+class TestPinOmoPlugin:
+    def test_pins_installer_plugin_to_resolved_version(self):
+        result = pin_omo_plugin(
+            {"plugin": ["other-plugin", "oh-my-opencode@latest"]},
+            "v4.19.0",
+        )
+
+        assert result["plugin"] == [
+            "other-plugin",
+            "oh-my-opencode@4.19.0",
+        ]
+
+    def test_leaves_config_without_omo_plugin_unchanged(self):
+        original = {"plugin": ["other-plugin"]}
+
+        assert pin_omo_plugin(original, "v4.19.0") == original

--- a/tests/test_install_inputs.py
+++ b/tests/test_install_inputs.py
@@ -64,7 +64,7 @@ class TestProviderInstallInputs:
         action_text = ACTION_YAML.read_text()
 
         assert "bot_login:" in action_text
-        assert "Optional GitHub login expected to author review output" in action_text
+        assert "required for pull_request" in action_text
 
     def test_review_output_verification_uses_pagination(self):
         action_text = ACTION_YAML.read_text()
@@ -77,6 +77,26 @@ class TestProviderInstallInputs:
         assert "steps.mode.outputs.value == 'review'" in action_text
         assert "REQUESTED_REVIEWER_LOGIN" in action_text
         assert "REACTION_USER_LOGIN" in action_text
+        assert (
+            action_text.count("steps.context.outputs.context_type == 'pr_opened'") == 3
+        )
+
+    def test_install_receives_token_and_configure_receives_omo_version(self):
+        action_text = ACTION_YAML.read_text()
+
+        install_step = action_text.split("- name: Install", 1)[1].split(
+            "- name: Configure", 1
+        )[0]
+        configure_step = action_text.split("- name: Configure", 1)[1].split(
+            "# === RUN AGENT ===", 1
+        )[0]
+
+        assert "GH_TOKEN: ${{ inputs.github_token }}" in install_step
+        assert "env -u GH_TOKEN" in INSTALL_SCRIPT.read_text()
+        assert (
+            "OH_MY_OPENCODE_VERSION: ${{ steps.version.outputs.oh_my_opencode }}"
+            in configure_step
+        )
 
     def test_review_output_verification_is_folded_into_final_status(self):
         action_text = ACTION_YAML.read_text()
@@ -93,6 +113,49 @@ class TestProviderInstallInputs:
         assert '--zai-coding-plan="${PROVIDER_ZAI_CODING_PLAN:-no}"' in install_text
         assert '--kimi-for-coding="${PROVIDER_KIMI_FOR_CODING:-no}"' in install_text
         assert '--opencode-go="${PROVIDER_OPENCODE_GO:-no}"' in install_text
+
+    def test_install_rejects_bad_release_digest(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            fake_bin = tmppath / "bin"
+            fake_bin.mkdir()
+
+            (fake_bin / "uname").write_text(
+                '#!/bin/bash\n[[ "$1" == "-s" ]] && echo Darwin || echo arm64\n'
+            )
+            (fake_bin / "gh").write_text(
+                "#!/bin/bash\n"
+                "printf '%s\\n' "
+                '\'{"assets":[{"name":"opencode-darwin-arm64.zip",'
+                '"browser_download_url":"https://example.invalid/opencode.zip",'
+                '"digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000"}]}\'\n'
+            )
+            (fake_bin / "curl").write_text(
+                "#!/bin/bash\n"
+                "while [[ $# -gt 0 ]]; do\n"
+                '  if [[ "$1" == "-o" ]]; then printf bad > "$2"; exit 0; fi\n'
+                "  shift\n"
+                "done\n"
+            )
+            for command in ("uname", "gh", "curl"):
+                (fake_bin / command).chmod(0o755)
+
+            result = subprocess.run(
+                ["bash", str(INSTALL_SCRIPT)],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HOME": str(tmppath / "home"),
+                    "OPENCODE_VERSION": "v1.18.4",
+                    "OH_MY_OPENCODE_VERSION": "v4.19.0",
+                    "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                },
+            )
+
+            assert result.returncode != 0
+            assert "Checksum verification failed" in result.stderr
 
     def test_configure_dumps_only_top_level_opencode_config_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_install_inputs.py
+++ b/tests/test_install_inputs.py
@@ -9,6 +9,7 @@ import tempfile
 ACTION_YAML = Path(__file__).parent.parent / "action.yaml"
 INSTALL_SCRIPT = Path(__file__).parent.parent / "scripts" / "install.sh"
 CONFIGURE_SCRIPT = Path(__file__).parent.parent / "scripts" / "configure.sh"
+VERSION_SCRIPT = Path(__file__).parent.parent / "scripts" / "version.sh"
 
 
 class TestProviderInstallInputs:
@@ -97,6 +98,38 @@ class TestProviderInstallInputs:
             "OH_MY_OPENCODE_VERSION: ${{ steps.version.outputs.oh_my_opencode }}"
             in configure_step
         )
+
+    def test_latest_omo_version_comes_from_npm(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            fake_bin = tmppath / "bin"
+            fake_bin.mkdir()
+            output = tmppath / "output"
+
+            (fake_bin / "gh").write_text("#!/bin/bash\necho v1.18.4\n")
+            (fake_bin / "curl").write_text(
+                "#!/bin/bash\n"
+                '[[ "$*" == *registry.npmjs.org/oh-my-opencode/latest* ]] '
+                "|| exit 2\n"
+                "printf '%s\\n' '{\"version\":\"4.19.1\"}'\n"
+            )
+            for command in ("gh", "curl"):
+                (fake_bin / command).chmod(0o755)
+
+            subprocess.run(
+                ["bash", str(VERSION_SCRIPT)],
+                check=True,
+                env={
+                    **os.environ,
+                    "GITHUB_OUTPUT": str(output),
+                    "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                },
+            )
+
+            assert output.read_text().splitlines() == [
+                "opencode=v1.18.4",
+                "oh_my_opencode=v4.19.1",
+            ]
 
     def test_review_output_verification_is_folded_into_final_status(self):
         action_text = ACTION_YAML.read_text()

--- a/tests/test_run_script.py
+++ b/tests/test_run_script.py
@@ -131,7 +131,7 @@ class TestRunScript:
                 )
             )
 
-            subprocess.run(
+            result = subprocess.run(
                 ["bash", str(RUN_SCRIPT)],
                 check=True,
                 capture_output=True,
@@ -154,6 +154,10 @@ class TestRunScript:
             assert data["agents"]["sisyphus"]["variant"] == "max"
             assert "prompt_append" in data["agents"]["sisyphus"]
             assert "Sisyphus" not in data["agents"]
+            assert (
+                "Runtime config: agent=sisyphus provider=github-copilot "
+                "model=claude-opus-4.6 variant=max" in result.stdout
+            )
 
     def test_provider_error_output_fails_run(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_verify_review_output.py
+++ b/tests/test_verify_review_output.py
@@ -61,6 +61,26 @@ class TestVerifyReviewOutput:
             assert ok is True
             assert message == "review verification succeeded"
 
+    def test_pr_opened_requires_review_from_known_actor(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            before = tmppath / "before.json"
+            after = tmppath / "after.json"
+            before.write_text("[]")
+            after.write_text(
+                json.dumps([{"id": 10, "user": {"login": "lambdaphus[bot]"}}])
+            )
+
+            ok, message = verify_review_output(
+                "lambdaphus[bot]",
+                "pr_opened",
+                before,
+                after,
+            )
+
+            assert ok is True
+            assert message == "review verification succeeded"
+
     def test_fails_when_no_new_review_exists(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmppath = Path(tmpdir)


### PR DESCRIPTION
OpenCode installation did not verify release asset digests. The generated
OMO plugin entry could also drift from the resolved CLI version, and
pull_request reviews bypassed the output verification gate.

Verify the GitHub-published SHA-256 digest, write the exact resolved OMO
plugin version while preserving explicit configuration overrides, and log
the configured agent, provider, model, and variant. Apply fail-closed
output validation to pull_request reviews and require an explicit
bot_login.
