### PR TITLE
fix(action): use canonical OMO config

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [`examples/agent.yaml`](./examples/agent.yaml) for a complete workflow with 
 | `config_json` | - | Full opencode.json content (advanced) |
 | `enabled_providers` | - | JSON array of provider IDs to enable |
 | `disabled_providers` | - | JSON array of provider IDs to disable |
-| `omo_config_json` | - | Full oh-my-opencode.json content (advanced) |
+| `omo_config_json` | - | Full oh-my-openagent.json content (advanced) |
 | `auth_json` | - | Full auth.json content (advanced) |
 | `agent_keywords` | `ultrawork` | Keywords to prepend for agent mode (triggers oh-my-opencode modes) |
 | `review_keywords` | `analyze` | Keywords to prepend for review mode (triggers oh-my-opencode modes) |

--- a/action.yaml
+++ b/action.yaml
@@ -118,7 +118,7 @@ inputs:
     description: JSON array of provider IDs to disable
     required: false
   omo_config_json:
-    description: Full oh-my-opencode.json content (advanced, overrides presets)
+    description: Full oh-my-openagent.json content (advanced, overrides presets)
     required: false
   auth_json:
     description: Full auth.json content (advanced, overrides API keys)

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -12,7 +12,7 @@ def read_json_object(path: Path) -> dict:
     except json.JSONDecodeError as exc:
         raise ValueError(f"{path} contains invalid JSON: {exc}") from exc
     if not isinstance(data, dict):
-        raise ValueError(f"{path} must contain a JSON object")
+        raise TypeError(f"{path} must contain a JSON object")
     return data
 
 
@@ -22,7 +22,7 @@ def parse_json_object(value: str, name: str) -> dict:
     except json.JSONDecodeError as exc:
         raise ValueError(f"{name} is invalid JSON: {exc}") from exc
     if not isinstance(data, dict):
-        raise ValueError(f"{name} must be a JSON object")
+        raise TypeError(f"{name} must be a JSON object")
     return data
 
 
@@ -221,7 +221,7 @@ def main():
     auth_json_provided = auth_json is not None
     try:
         auth = build_auth(anthropic_key, openai_key, gemini_key, auth_json)
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
@@ -233,7 +233,8 @@ def main():
     config_dir = Path.home() / ".config" / "opencode"
     config_dir.mkdir(parents=True, exist_ok=True)
     config_file = config_dir / "opencode.json"
-    omo_file = config_dir / "oh-my-opencode.json"
+    omo_file = config_dir / "oh-my-openagent.json"
+    legacy_omo_file = config_dir / "oh-my-opencode.json"
 
     override_config = {}
     try:
@@ -244,13 +245,13 @@ def main():
             disabled_providers,
             provider_settings,
         )
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
     try:
         base_config = read_json_object(config_file) if config_file.exists() else {}
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
@@ -264,6 +265,16 @@ def main():
         merged_config = merge_configs(merged_config, override_config)
     config_file.write_text(json.dumps(merged_config, indent=2))
 
+    plugins = merged_config.get("plugin", [])
+    plugin_packages = {
+        entry.split("@", 1)[0] for entry in plugins if isinstance(entry, str)
+    }
+    omo_packages = plugin_packages & {"oh-my-openagent", "oh-my-opencode"}
+    if (
+        "oh-my-opencode" in plugin_packages and "oh-my-openagent" not in plugin_packages
+    ) or (not omo_packages and not omo_file.exists() and legacy_omo_file.exists()):
+        omo_file = legacy_omo_file
+
     omo_defaults = generate_omo_config(
         commit_footer,
         include_co_authored_by,
@@ -274,7 +285,7 @@ def main():
 
     try:
         omo_base = read_json_object(omo_file) if omo_file.exists() else {}
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
@@ -283,7 +294,7 @@ def main():
     if omo_config_json:
         try:
             omo_override = parse_json_object(omo_config_json, "OMO_CONFIG_JSON")
-        except ValueError as exc:
+        except (TypeError, ValueError) as exc:
             print(f"Error: {exc}", file=sys.stderr)
             sys.exit(1)
         merged_omo = merge_configs(merged_omo, omo_override)

--- a/scripts/detect_mode.py
+++ b/scripts/detect_mode.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python3
 """Detect agent mode from event context."""
 
 import os
 import re
-
 
 # Patterns that indicate an explicit review request.
 # These are matched case-insensitively and require the bot to be mentioned.

--- a/scripts/fetch_threads.py
+++ b/scripts/fetch_threads.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python3
 """Fetch unresolved review threads from a pull request via GraphQL."""
 
 import json
 import os
 import subprocess
 import sys
-
 
 QUERY = """
 query($owner: String!, $repo: String!, $number: Int!) {

--- a/scripts/resolve_thread.py
+++ b/scripts/resolve_thread.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python3
 """Resolve a review thread via GraphQL mutation."""
 
 import json
 import subprocess
 import sys
-
 
 RESOLVE_MUTATION = """
 mutation($threadId: ID!) {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -3,7 +3,23 @@ set -uo pipefail
 
 ACTION_PATH="${ACTION_PATH:-.}"
 PROMPT_PATH="${PROMPT_PATH:-.github/prompts}"
-OMO_FILE="$HOME/.config/opencode/oh-my-opencode.json"
+OMO_FILE="$HOME/.config/opencode/oh-my-openagent.json"
+OPENCODE_FILE="$HOME/.config/opencode/opencode.json"
+OMO_PACKAGE=""
+if [[ -f "$OPENCODE_FILE" ]]; then
+  OMO_PACKAGE=$(jq -r '
+    [.plugin[]? | select(type == "string") | split("@")[0]]
+    | if index("oh-my-openagent") then "oh-my-openagent"
+      elif index("oh-my-opencode") then "oh-my-opencode"
+      else empty end
+  ' "$OPENCODE_FILE")
+fi
+if [[ "$OMO_PACKAGE" == "oh-my-opencode" ]]; then
+  OMO_FILE="$HOME/.config/opencode/oh-my-opencode.json"
+elif [[ -z "$OMO_PACKAGE" && ! -f "$OMO_FILE" \
+  && -f "$HOME/.config/opencode/oh-my-opencode.json" ]]; then
+  OMO_FILE="$HOME/.config/opencode/oh-my-opencode.json"
+fi
 
 is_truthy() {
   local value="${1:-}"

--- a/scripts/substitute.py
+++ b/scripts/substitute.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
+import json
 import re
 import sys
-import json
 
 TRANSFORM_LIMIT = 10
 VAR_PATTERN = re.compile(r"\{\{\s*(\w+)\s*\}\}")

--- a/scripts/verify_review_output.py
+++ b/scripts/verify_review_output.py
@@ -1,11 +1,8 @@
-#!/usr/bin/env python3
-
 """Verify review mode produced a new PR review."""
 
 import json
 import sys
 from pathlib import Path
-
 
 REVIEW_CONTEXT_TYPES = {"pr_comment", "pr_opened", "pr_review_request"}
 
@@ -17,7 +14,7 @@ def load_reviews(path: Path) -> list[dict]:
         raise ValueError(f"{path} contains invalid JSON: {exc}") from exc
 
     if not isinstance(data, list):
-        raise ValueError(f"{path} must contain a JSON array")
+        raise TypeError(f"{path} must contain a JSON array")
 
     return [item for item in data if isinstance(item, dict)]
 
@@ -75,7 +72,7 @@ def main() -> None:
             before_path,
             after_path,
         )
-    except ValueError as exc:
+    except (TypeError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import importlib.util
 from pathlib import Path
 

--- a/tests/test_format_output.py
+++ b/tests/test_format_output.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import importlib.util
 import io
 from pathlib import Path

--- a/tests/test_install_inputs.py
+++ b/tests/test_install_inputs.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python3
-
 import os
-from pathlib import Path
 import subprocess
 import tempfile
-
+from pathlib import Path
 
 ACTION_YAML = Path(__file__).parent.parent / "action.yaml"
 INSTALL_SCRIPT = Path(__file__).parent.parent / "scripts" / "install.sh"
@@ -216,6 +213,73 @@ class TestProviderInstallInputs:
 
             assert "==> " in result.stdout
             assert "opencode.json" in result.stdout
-            assert "oh-my-opencode.json" in result.stdout
+            assert "oh-my-openagent.json" in result.stdout
             assert "ignored.json" not in result.stdout
             assert '{"nested": true}' not in result.stdout
+
+    def test_configure_selects_legacy_omo_config_for_legacy_plugin(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            config_dir = home / ".config" / "opencode"
+            config_dir.mkdir(parents=True)
+            legacy_file = config_dir / "oh-my-opencode.json"
+            legacy_file.write_text(
+                '{"agents": {"sisyphus": {"model": "legacy/model"}}}'
+            )
+            canonical_file = config_dir / "oh-my-openagent.json"
+            canonical_file.write_text(
+                '{"agents": {"sisyphus": {"model": "stale/model"}}}'
+            )
+            (config_dir / "opencode.json").write_text(
+                '{"plugin": ["oh-my-opencode@4.18.0"]}'
+            )
+
+            subprocess.run(
+                ["bash", str(CONFIGURE_SCRIPT)],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "ACTION_PATH": str(ACTION_YAML.parent),
+                    "HOME": str(home),
+                    "AUTH_JSON": '{"github-copilot": {"type": "oauth"}}',
+                    "PROVIDER_ANTHROPIC": "no",
+                    "PROVIDER_COPILOT": "yes",
+                },
+            )
+
+            assert "legacy/model" in legacy_file.read_text()
+            assert "disabled_skills" in legacy_file.read_text()
+            assert "disabled_skills" not in canonical_file.read_text()
+
+    def test_configure_selects_canonical_omo_config_for_config_override(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir) / "home"
+            config_dir = home / ".config" / "opencode"
+            config_dir.mkdir(parents=True)
+            legacy_file = config_dir / "oh-my-opencode.json"
+            legacy_file.write_text('{"agents": {"sisyphus": {"model": "stale/model"}}}')
+            (config_dir / "opencode.json").write_text(
+                '{"plugin": ["oh-my-opencode@4.18.0"]}'
+            )
+
+            subprocess.run(
+                ["bash", str(CONFIGURE_SCRIPT)],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "ACTION_PATH": str(ACTION_YAML.parent),
+                    "HOME": str(home),
+                    "AUTH_JSON": '{"github-copilot": {"type": "oauth"}}',
+                    "CONFIG_JSON": '{"plugin": ["oh-my-openagent@4.19.1"]}',
+                    "PROVIDER_ANTHROPIC": "no",
+                    "PROVIDER_COPILOT": "yes",
+                },
+            )
+
+            canonical_file = config_dir / "oh-my-openagent.json"
+            assert "disabled_skills" in canonical_file.read_text()
+            assert "disabled_skills" not in legacy_file.read_text()

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import importlib.util
 import tempfile
 from pathlib import Path

--- a/tests/test_replay_commits.py
+++ b/tests/test_replay_commits.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import sys
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_run_script.py
+++ b/tests/test_run_script.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python3
-
 import json
 import os
 import subprocess
 import tempfile
 from pathlib import Path
 
+import pytest
 
 RUN_SCRIPT = Path(__file__).parent.parent / "scripts" / "run.sh"
 ACTION_PATH = Path(__file__).parent.parent
@@ -102,7 +101,29 @@ class TestRunScript:
             else:
                 log_file.write_text(original)
 
-    def test_prompt_append_preserves_sisyphus_model(self):
+    @pytest.mark.parametrize(
+        ("omo_filename", "plugin", "stale_filename"),
+        [
+            ("oh-my-openagent.json", "oh-my-openagent@4.19.1", None),
+            ("oh-my-opencode.json", "oh-my-opencode@4.18.0", None),
+            (
+                "oh-my-opencode.json",
+                "oh-my-opencode@4.18.0",
+                "oh-my-openagent.json",
+            ),
+            (
+                "oh-my-openagent.json",
+                "oh-my-openagent@4.19.1",
+                "oh-my-opencode.json",
+            ),
+        ],
+    )
+    def test_prompt_append_preserves_sisyphus_model(
+        self,
+        omo_filename,
+        plugin,
+        stale_filename,
+    ):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmppath = Path(tmpdir)
             fake_bin = tmppath / "bin"
@@ -117,7 +138,8 @@ class TestRunScript:
             home = tmppath / "home"
             omo_dir = home / ".config" / "opencode"
             omo_dir.mkdir(parents=True)
-            omo_file = omo_dir / "oh-my-opencode.json"
+            (omo_dir / "opencode.json").write_text(json.dumps({"plugin": [plugin]}))
+            omo_file = omo_dir / omo_filename
             omo_file.write_text(
                 json.dumps(
                     {
@@ -130,6 +152,11 @@ class TestRunScript:
                     }
                 )
             )
+            stale_file = omo_dir / stale_filename if stale_filename else None
+            if stale_file:
+                stale_file.write_text(
+                    '{"agents": {"sisyphus": {"model": "stale/model"}}}'
+                )
 
             result = subprocess.run(
                 ["bash", str(RUN_SCRIPT)],
@@ -154,6 +181,8 @@ class TestRunScript:
             assert data["agents"]["sisyphus"]["variant"] == "max"
             assert "prompt_append" in data["agents"]["sisyphus"]
             assert "Sisyphus" not in data["agents"]
+            if stale_file:
+                assert "prompt_append" not in stale_file.read_text()
             assert (
                 "Runtime config: agent=sisyphus provider=github-copilot "
                 "model=claude-opus-4.6 variant=max" in result.stdout

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python3
-
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from substitute import substitute, VAR_PATTERN
+from substitute import VAR_PATTERN, substitute
 
 
 class TestVarPattern:

--- a/tests/test_vars.py
+++ b/tests/test_vars.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import sys
 import tempfile
 from pathlib import Path

--- a/tests/test_verify_review_output.py
+++ b/tests/test_verify_review_output.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import sys
 import tempfile


### PR DESCRIPTION
The renamed plugin writes oh-my-openagent.json, while the action still updated and read oh-my-opencode.json. This discarded installer-selected models and could route runs through a disabled provider.

Select the config file from the installed plugin and retain the legacy path for older oh-my-opencode versions.