### PR TITLE
fix(action): initialize OMO provider caches

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -600,6 +600,10 @@ runs:
         SKILL_ENABLE_FRONTEND_UI_UX: ${{ inputs.skill_enable_frontend_ui_ux }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
+    - name: Warm provider cache
+      shell: bash
+      run: ${{ github.action_path }}/scripts/warmup.sh
+
     # === RUN AGENT ===
     - name: Run agent
       id: agent

--- a/scripts/warmup.sh
+++ b/scripts/warmup.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+set -euo pipefail
+
+CACHE_DIR="$HOME/.cache/oh-my-opencode"
+CONNECTED_CACHE="$CACHE_DIR/connected-providers.json"
+PROVIDER_MODELS_CACHE="$CACHE_DIR/provider-models.json"
+PORT="${OPENCODE_WARMUP_PORT:-4096}"
+SERVER_URL="http://127.0.0.1:$PORT"
+LOG_FILE=""
+PROVIDER_SNAPSHOT=""
+SERVER_PID=""
+
+# Invoked by the EXIT trap below.
+# shellcheck disable=SC2329
+cleanup() {
+  if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$LOG_FILE" ]]; then
+    rm -f "$LOG_FILE"
+  fi
+  if [[ -n "$PROVIDER_SNAPSHOT" ]]; then
+    rm -f "$PROVIDER_SNAPSHOT"
+  fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+LOG_FILE=$(mktemp -t dobbyphus-warmup.XXXXXX)
+PROVIDER_SNAPSHOT=$(mktemp -t dobbyphus-providers.XXXXXX)
+
+env -u OPENCODE_CLI_RUN_MODE opencode serve \
+  --hostname 127.0.0.1 \
+  --port "$PORT" >"$LOG_FILE" 2>&1 &
+SERVER_PID=$!
+
+fail() {
+  echo "$1" >&2
+  cat "$LOG_FILE" >&2
+  exit 1
+}
+
+server_ready=false
+for _ in {1..100}; do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    break
+  fi
+  if curl -fsS --max-time 1 "$SERVER_URL/global/health" >/dev/null 2>&1; then
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+      server_ready=true
+    fi
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ "$server_ready" != "true" ]]; then
+  fail "OpenCode warm-up server failed to start."
+fi
+
+if ! curl -fsS --max-time 45 "$SERVER_URL/provider" >"$PROVIDER_SNAPSHOT"; then
+  fail "OpenCode warm-up could not read the provider snapshot."
+fi
+
+if ! jq -e '
+  .connected as $connected
+  | (.all // []) as $all
+  | ($connected | type == "array" and length > 0)
+    and (
+      [
+        $connected[] as $id
+        | $all[]?
+        | select(.id == $id and ((.models // {}) | length > 0))
+      ]
+      | length > 0
+    )
+' "$PROVIDER_SNAPSHOT" >/dev/null; then
+  fail "OpenCode warm-up found no connected provider with models."
+fi
+
+if ! curl -fsS --max-time 45 \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  "$SERVER_URL/session" >/dev/null; then
+  fail "OpenCode warm-up session creation failed."
+fi
+
+cache_ready=false
+for _ in {1..160}; do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    break
+  fi
+  if [[ -f "$CONNECTED_CACHE" && -f "$PROVIDER_MODELS_CACHE" ]] && \
+    jq -e \
+      --slurpfile snapshot "$PROVIDER_SNAPSHOT" \
+      --slurpfile connected "$CONNECTED_CACHE" '
+        . as $models
+        | $snapshot[0].connected as $expected
+        | (($expected - ($connected[0].connected // [])) | length == 0)
+          and (($expected - ($models.connected // [])) | length == 0)
+          and (
+            [
+              $expected[] as $provider
+              | ($models.models[$provider] // [])
+              | length
+            ]
+            | any(. > 0)
+          )
+      ' "$PROVIDER_MODELS_CACHE" >/dev/null 2>&1; then
+    if kill -0 "$SERVER_PID" 2>/dev/null; then
+      cache_ready=true
+    fi
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ "$cache_ready" != "true" ]]; then
+  fail "OpenCode warm-up did not create complete provider caches."
+fi

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,0 +1,292 @@
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from textwrap import dedent
+
+ROOT = Path(__file__).parent.parent
+WARMUP_SCRIPT = ROOT / "scripts" / "warmup.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(dedent(content).lstrip())
+    path.chmod(0o755)
+
+
+def test_warmup_waits_for_complete_provider_cache() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        home = tmp_path / "home"
+        home.mkdir()
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+
+        fake_opencode = fake_bin / "opencode"
+        _write_executable(
+            fake_opencode,
+            """\
+                #!/bin/bash
+                set -euo pipefail
+                while [[ ! -f "$HOME/session-requested" ]]; do
+                  sleep 0.05
+                done
+                mkdir -p "$HOME/.cache/oh-my-opencode"
+                printf '%s\n' '{"connected":["github-copilot"]}' \
+                  > "$HOME/.cache/oh-my-opencode/connected-providers.json"
+                sleep 0.5
+                printf '%s\n' \
+                  '{"models":{"github-copilot":[{"id":"claude-opus-5"}]},"connected":["github-copilot"]}' \
+                  > "$HOME/.cache/oh-my-opencode/provider-models.json"
+                sleep 30
+                """,
+        )
+
+        fake_curl = fake_bin / "curl"
+        _write_executable(
+            fake_curl,
+            """\
+                #!/bin/bash
+                set -euo pipefail
+                if [[ "$*" == *"/global/health"* ]]; then
+                  exit 0
+                fi
+                if [[ "$*" == *"/provider"* ]]; then
+                  touch "$HOME/provider-requested"
+                  printf '%s\n' \
+                    '{"all":[{"id":"github-copilot","models":{"claude-opus-5":{"id":"claude-opus-5"}}}],"connected":["github-copilot"]}'
+                  exit 0
+                fi
+                if [[ "$*" == *"-X POST"* && "$*" == *"/session"* ]]; then
+                  touch "$HOME/session-requested"
+                  printf '{}\n'
+                  exit 0
+                fi
+                exit 1
+                """,
+        )
+
+        result = subprocess.run(
+            ["bash", str(WARMUP_SCRIPT)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "HOME": str(home),
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            },
+        )
+
+        cache_dir = home / ".cache" / "oh-my-opencode"
+        assert result.returncode == 0, result.stderr
+        assert (home / "provider-requested").exists()
+        assert (cache_dir / "connected-providers.json").exists()
+        assert (cache_dir / "provider-models.json").exists()
+        assert "scripts/warmup.sh" in (ROOT / "action.yaml").read_text()
+
+
+def test_warmup_cleans_up_and_exits_on_lifecycle_failures() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        home = tmp_path / "home"
+        home.mkdir()
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        log_file = home / "warmup.log"
+        provider_snapshot = home / "providers.json"
+        curl_started = home / "curl-started"
+
+        fake_mktemp = fake_bin / "mktemp"
+        fake_mktemp.write_text(
+            dedent(
+                """\
+                #!/bin/bash
+                set -euo pipefail
+                if [[ "$*" == *"dobbyphus-warmup"* ]]; then
+                  path="$HOME/warmup.log"
+                elif [[ "$WARMUP_TEST_MODE" == "allocation-failure" ]]; then
+                  exit 1
+                else
+                  path="$HOME/providers.json"
+                fi
+                touch "$path"
+                printf '%s\n' "$path"
+                """
+            )
+        )
+        fake_mktemp.chmod(0o755)
+
+        fake_opencode = fake_bin / "opencode"
+        fake_opencode.write_text("#!/bin/bash\nsleep 30\n")
+        fake_opencode.chmod(0o755)
+
+        fake_curl = fake_bin / "curl"
+        fake_curl.write_text(
+            dedent(
+                """\
+                #!/bin/bash
+                set -euo pipefail
+                touch "$HOME/curl-started"
+                sleep 30
+                """
+            )
+        )
+        fake_curl.chmod(0o755)
+
+        env = {
+            **os.environ,
+            "HOME": str(home),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        }
+        allocation_failure = subprocess.run(
+            ["bash", str(WARMUP_SCRIPT)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={**env, "WARMUP_TEST_MODE": "allocation-failure"},
+        )
+
+        assert allocation_failure.returncode != 0
+        assert not log_file.exists()
+
+        process = subprocess.Popen(
+            ["bash", str(WARMUP_SCRIPT)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+            env={**env, "WARMUP_TEST_MODE": "signal"},
+        )
+        stderr = ""
+        try:
+            deadline = time.monotonic() + 2
+            while (
+                not curl_started.exists()
+                and process.poll() is None
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.01)
+            assert curl_started.exists()
+
+            os.killpg(process.pid, signal.SIGTERM)
+            _, stderr = process.communicate(timeout=2)
+        finally:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            if process.poll() is None:
+                process.wait()
+
+        assert process.returncode == 143, (process.returncode, stderr)
+        assert not log_file.exists()
+        assert not provider_snapshot.exists()
+
+
+def test_warmup_rejects_responses_after_server_exits() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        home = tmp_path / "home"
+        cache_dir = home / ".cache" / "oh-my-opencode"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "connected-providers.json").write_text(
+            '{"connected":["github-copilot"]}'
+        )
+        (cache_dir / "provider-models.json").write_text(
+            '{"models":{"github-copilot":[{"id":"claude-opus-5"}]},'
+            '"connected":["github-copilot"]}'
+        )
+
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        _write_executable(
+            fake_bin / "opencode",
+            """\
+            #!/bin/bash
+            printf 'server exited\n' >&2
+            touch "$HOME/server-exited"
+            """,
+        )
+        _write_executable(
+            fake_bin / "curl",
+            """\
+            #!/bin/bash
+            set -euo pipefail
+            if [[ "$*" == *"/global/health"* ]]; then
+              while [[ ! -f "$HOME/server-exited" ]]; do
+                /bin/sleep 0.01
+              done
+              /bin/sleep 0.05
+              exit 0
+            fi
+            if [[ "$*" == *"/provider"* ]]; then
+              printf '%s\n' \
+                '{"all":[{"id":"github-copilot","models":{"claude-opus-5":{"id":"claude-opus-5"}}}],"connected":["github-copilot"]}'
+              exit 0
+            fi
+            printf '{}\n'
+            """,
+        )
+
+        result = subprocess.run(
+            ["bash", str(WARMUP_SCRIPT)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "HOME": str(home),
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            },
+        )
+
+        assert result.returncode != 0
+        assert "server exited" in result.stderr
+
+
+def test_warmup_rejects_provider_cache_without_models() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        home = tmp_path / "home"
+        cache_dir = home / ".cache" / "oh-my-opencode"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "connected-providers.json").write_text(
+            '{"connected":["github-copilot"]}'
+        )
+        (cache_dir / "provider-models.json").write_text(
+            '{"models":{"github-copilot":[]},"connected":["github-copilot"]}'
+        )
+
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        _write_executable(fake_bin / "opencode", "#!/bin/bash\n/bin/sleep 30\n")
+        _write_executable(
+            fake_bin / "curl",
+            """\
+            #!/bin/bash
+            if [[ "$*" == *"/provider"* ]]; then
+              printf '%s\n' \
+                '{"all":[{"id":"github-copilot","models":{"claude-opus-5":{"id":"claude-opus-5"}}}],"connected":["github-copilot"]}'
+            else
+              printf '{}\n'
+            fi
+            """,
+        )
+        _write_executable(fake_bin / "sleep", "#!/bin/bash\nexit 0\n")
+
+        result = subprocess.run(
+            ["bash", str(WARMUP_SCRIPT)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "HOME": str(home),
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            },
+        )
+
+        assert result.returncode != 0
+        assert "did not create complete provider caches" in result.stderr


### PR DESCRIPTION
OMO resolves model fallbacks before its provider caches are populated on fresh runners. Copilot therefore appears unavailable and OMO selects Anthropic even when that provider is disabled.

Start a temporary OpenCode server before launching the agent to populate and validate both cache files. Abort with the server log unless a connected provider exposes models and the generated caches contain usable data.